### PR TITLE
Add CI pipeline, ruff linting, and git hooks

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Validate conventional commit format
+# Pattern: type(scope): message  OR  type: message
+COMMIT_MSG=$(head -1 "$1")
+PATTERN="^(feat|fix|chore|docs|style|refactor|perf|test|ci|build|revert)(\(.+\))?: .{1,72}$"
+
+if ! echo "$COMMIT_MSG" | grep -qE "$PATTERN"; then
+    echo ""
+    echo "Invalid commit message format."
+    echo "Expected: <type>(<scope>): <description>"
+    echo ""
+    echo "Types: feat, fix, chore, docs, style, refactor, perf, test, ci, build, revert"
+    echo "Max subject length: 72 chars"
+    echo ""
+    echo "Got: $COMMIT_MSG"
+    exit 1
+fi

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Check if ruff is available
+if ! command -v ruff &> /dev/null; then
+    echo "ruff not found. Install with: pip install -e '.[dev]'"
+    exit 1
+fi
+
+# Get staged Python files
+STAGED_PY=$(git diff --cached --name-only --diff-filter=ACM | grep '\.py$' || true)
+
+if [ -z "$STAGED_PY" ]; then
+    exit 0
+fi
+
+echo "Running ruff format check..."
+if ! ruff format --check $STAGED_PY; then
+    echo ""
+    echo "Format check failed. Run: ruff format src/"
+    exit 1
+fi
+
+echo "Running ruff lint..."
+if ! ruff check $STAGED_PY; then
+    echo ""
+    echo "Lint check failed. Run: ruff check --fix src/"
+    exit 1
+fi
+
+echo "All checks passed."

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,61 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install ruff
+
+      - name: Check formatting
+        run: ruff format --check src/
+
+      - name: Lint
+        run: ruff check src/
+
+  build:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install package
+        run: pip install .
+
+      - name: Verify CLI entry point
+        run: git-wt --version
+
+  test:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install package with dev deps
+        run: pip install -e ".[dev]"
+
+      - name: Run tests
+        run: pytest --tb=short -q

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ src/cmds/<cmd>/
 
 - Plain classes with `pass` body. No dataclass, no fields, no methods.
 - Exception: `GitAuthError(Exception)` for errors that must be raised.
-- Filename = class name in snake_case: `not_bare_repo_err.py` -> `NotBareRepoErr`
+- Filename = class name snake_case: `not_bare_repo_err.py` -> `NotBareRepoErr`
 
 ### Helpers: `src/helpers/`
 
@@ -58,7 +58,7 @@ One concern per file: `logger.py`, `auth_agent_callback.py`, `find_git.py`, `con
 
 ### main.py
 
-Only place with Click decorators, `exit()` calls, and exhaustive `match`/`case` on results.
+Only place with Click decorators, `exit()` calls, exhaustive `match`/`case` on results.
 Constructs Args dataclass -> calls command function -> matches result -> logs + exits.
 
 ## Coding Conventions
@@ -94,8 +94,8 @@ Constructs Args dataclass -> calls command function -> matches result -> logs + 
 - `| None` unions, not `Optional[T]`
 
 **Formatting:**
-- Spaces inside parentheses for multi-token expressions: `str( path.parent )` — deliberate style choice
-- `@dataclass()` with explicit parentheses even when no args
+- Spaces inside parens for multi-token expressions: `str( path.parent )` — deliberate style choice
+- `@dataclass()` with explicit parens even when no args
 - `@final` and `@override` in helper classes
 - `field(default_factory=list)` for mutable defaults
 
@@ -123,12 +123,12 @@ From README shower thoughts + current state:
 
 ## Do NOT
 
-- Add features/refactors beyond what's asked
-- Change logging style (especially: don't move `log = ...` to module level, don't use f-strings in log calls)
+- Add features/refactors beyond what asked
+- Change logging style (don't move `log = ...` to module level, don't use f-strings in log calls)
 - Add type annotations/docstrings to unchanged code
 - Create abstractions for one-off operations
 - Use `Optional[T]` instead of `| None`
-- Use exceptions where Result pattern is used
+- Use exceptions where Result pattern used
 - Put match/case logic inside command functions (belongs in main.py only)
 
 ## Do

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
 dev = [
     "pytest>=8.0",
     "pytest-cov",
+    "ruff>=0.8",
 ]
 
 [project.scripts]
@@ -32,5 +33,23 @@ packages = ["src"]
 testpaths = ["tests"]
 pythonpath = ["."]
 
-# [tool.mypy]
-# plugins = ["returns.contrib.mypy.returns_plugin"]
+[tool.ruff]
+target-version = "py311"
+line-length = 140
+
+[tool.ruff.lint]
+select = [
+    "E",    # pycodestyle errors
+    "W",    # pycodestyle warnings
+    "F",    # pyflakes
+    "I",    # isort
+    "UP",   # pyupgrade
+    "B",    # flake8-bugbear
+    "SIM",  # flake8-simplify
+]
+ignore = [
+    "E501",  # line too long (handled by formatter with line-length above)
+]
+
+[tool.ruff.format]
+quote-style = "double"

--- a/src/cmds/add/cmd_add.py
+++ b/src/cmds/add/cmd_add.py
@@ -1,39 +1,48 @@
-from fnmatch import fnmatch
 import logging
 import os
-import pygit2 as pg
-
-from result import Result, Ok, Err
-from shutil import copy2, copytree
+from fnmatch import fnmatch
 from pathlib import Path
+from shutil import copy2, copytree
 
+import pygit2 as pg
+from result import Err, Ok, Result
+
+from ...errors.derived_branch_does_not_exist import DeriveBranchDoesNotExist
+from ...errors.no_fast_forward_merge import NoFastForwardMerge
+from ...errors.not_bare_repo_err import NotBareRepoErr
+from ...errors.worktree_already_exists import WorktreeAlreadyExistsErr
+from ...errors.worktree_creation_err import WorktreeCreationErr
+from ...helpers.find_git import get_git_dir
 from .args_add import AddArgs
 from .result_add import AddWorktreeError
-
-from ...errors.no_fast_forward_merge import NoFastForwardMerge
-from ...errors.worktree_already_exists import WorktreeAlreadyExistsErr
-from ...errors.derived_branch_does_not_exist import DeriveBranchDoesNotExist
-from ...helpers.find_git import get_git_dir
-from ...errors.not_bare_repo_err import NotBareRepoErr
-from ...errors.worktree_creation_err import WorktreeCreationErr
 
 
 def add_worktree(add_args: AddArgs) -> Result[None, AddWorktreeError]:
     log = logging.getLogger(__name__)
 
-    branch_name: str = add_args.new_branch_name if add_args.should_nest_dirs else add_args.new_branch_name.replace('/', '-')
+    branch_name: str = add_args.new_branch_name if add_args.should_nest_dirs else add_args.new_branch_name.replace("/", "-")
     current_path: str = os.getcwd()
 
-    log.debug("Attempting to find git dir; should_nest_dirs=%s, branch_path=%s, current_path=%s", add_args.should_nest_dirs, branch_name, current_path)
+    log.debug(
+        "Attempting to find git dir; should_nest_dirs=%s, branch_path=%s, current_path=%s",
+        add_args.should_nest_dirs,
+        branch_name,
+        current_path,
+    )
 
     git_dir = get_git_dir(current_path)
     if not git_dir:
-        log.warning("This isn't a bare git repository; should_nest_dirs=%s, branch_path=%s, current_path=%s", add_args.should_nest_dirs, branch_name, current_path)
+        log.warning(
+            "This isn't a bare git repository; should_nest_dirs=%s, branch_path=%s, current_path=%s",
+            add_args.should_nest_dirs,
+            branch_name,
+            current_path,
+        )
         return Err(NotBareRepoErr())
 
     derived_branch_exists: Path = Path(git_dir, add_args.derive_from_branch)
     if not derived_branch_exists.exists(follow_symlinks=True):
-        log.warning("Derived branch does not exist; derived_branch_path=%s", str( derived_branch_exists.absolute ))
+        log.warning("Derived branch does not exist; derived_branch_path=%s", str(derived_branch_exists.absolute))
         return Err(DeriveBranchDoesNotExist())
 
     # TODO: Specify the repo to be based on the derived_branch
@@ -44,7 +53,12 @@ def add_worktree(add_args: AddArgs) -> Result[None, AddWorktreeError]:
 
     # Technically shouldn't be hittable, as get_git_dir checks for that
     if not bare_repo.is_bare:
-        log.warning("This isn't a bare git repository; should_nest_dirs=%s, branch_path=%s, current_path=%s", add_args.should_nest_dirs, branch_name, current_path)
+        log.warning(
+            "This isn't a bare git repository; should_nest_dirs=%s, branch_path=%s, current_path=%s",
+            add_args.should_nest_dirs,
+            branch_name,
+            current_path,
+        )
         return Err(NotBareRepoErr())
 
     # TODO: Check if this fetches main branch, if configured
@@ -74,7 +88,6 @@ def add_worktree(add_args: AddArgs) -> Result[None, AddWorktreeError]:
         # True merge required — pygit2 can do it but you'd need to handle conflicts
         return Err(NoFastForwardMerge())
 
-
     new_worktree: pg.Worktree | None = None
     wt_path = Path(git_dir, branch_name).absolute()
 
@@ -91,24 +104,28 @@ def add_worktree(add_args: AddArgs) -> Result[None, AddWorktreeError]:
         return Err(WorktreeCreationErr())
 
     except pg.AlreadyExistsError:
-        log.error("Worktree with the same name already exists; worktree_path=%s, worktree_name=%s, repository=%s", wt_path, branch_name, bare_repo)
+        log.error(
+            "Worktree with the same name already exists; worktree_path=%s, worktree_name=%s, repository=%s", wt_path, branch_name, bare_repo
+        )
 
         return Err(WorktreeAlreadyExistsErr())
-
 
     assert new_worktree is not None, "The new worktree must be created. Something wasn not handled correctly"
     assert new_worktree.name == branch_name, "Worktree name must equal to the branch name provided"
     assert new_worktree.path == str(wt_path), "The path of the worktree must be the same as the given path for worktree creation"
 
-
     derive_branch_path: Path = Path(git_dir, add_args.derive_from_branch)
-    log.info("Preparing for file copying; copy_from=%s, copy_to=%s", str( derive_branch_path ), new_worktree.path)
+    log.info("Preparing for file copying; copy_from=%s, copy_to=%s", str(derive_branch_path), new_worktree.path)
 
     derived_repo = pg.Repository(derive_branch_path)
     log.debug("Derived repository opened; derived_repository=%s; derived_repo_workdir=%s", derived_repo, derived_repo.workdir)
 
     git_ignored_files = [Path(derived_repo.workdir, ignored) for ignored in derived_repo.status(untracked_files="no", ignored=True)]
-    git_ignored_filtered_files = [ignored_file for ignored_file in git_ignored_files if not any(fnmatch(ignored_file.name, excluded_glob) for excluded_glob in add_args.exclude)]
+    git_ignored_filtered_files = [
+        ignored_file
+        for ignored_file in git_ignored_files
+        if not any(fnmatch(ignored_file.name, excluded_glob) for excluded_glob in add_args.exclude)
+    ]
 
     log.debug("Found git ignored files from derived branch; git_ignored_files=%s", git_ignored_filtered_files)
 

--- a/src/cmds/add/result_add.py
+++ b/src/cmds/add/result_add.py
@@ -1,8 +1,7 @@
 from ...errors.derived_branch_does_not_exist import DeriveBranchDoesNotExist
 from ...errors.no_fast_forward_merge import NoFastForwardMerge
 from ...errors.not_bare_repo_err import NotBareRepoErr
-from ...errors.worktree_creation_err import WorktreeCreationErr
 from ...errors.worktree_already_exists import WorktreeAlreadyExistsErr
-
+from ...errors.worktree_creation_err import WorktreeCreationErr
 
 AddWorktreeError = NotBareRepoErr | WorktreeCreationErr | WorktreeAlreadyExistsErr | DeriveBranchDoesNotExist | NoFastForwardMerge

--- a/src/cmds/clone/args_clone.py
+++ b/src/cmds/clone/args_clone.py
@@ -6,4 +6,3 @@ from pathlib import Path
 class CloneArgs:
     repository_link: str
     dest: Path
-

--- a/src/cmds/clone/cmd_clone.py
+++ b/src/cmds/clone/cmd_clone.py
@@ -1,15 +1,14 @@
 import logging
 import os
-import pygit2 as pg
-
 from pathlib import Path
+
+import pygit2 as pg
 from result import Err, Ok, Result
 
-from ...errors.path_cannot_be_file import PathCannotBeFile
 from ...errors.directory_not_empty import DirectoryNotEmpty
+from ...errors.path_cannot_be_file import PathCannotBeFile
 from ...errors.worktree_creation_err import WorktreeCreationErr
 from ...helpers.auth_agent_callback import AuthAgentCallback
-
 from .args_clone import CloneArgs
 from .result_clone import CloneRepositoryErr
 
@@ -31,11 +30,7 @@ def clone_repository(clone_args: CloneArgs) -> Result[pg.Repository, CloneReposi
     repo: pg.Repository | None = None
     try:
         repo = pg.clone_repository(
-            url=clone_args.repository_link,
-            path=str(clone_args.dest.absolute()),
-            bare=True,
-            proxy=True,
-            callbacks=AuthAgentCallback()
+            url=clone_args.repository_link, path=str(clone_args.dest.absolute()), bare=True, proxy=True, callbacks=AuthAgentCallback()
         )
 
     except pg.GitError as e:

--- a/src/cmds/clone/result_clone.py
+++ b/src/cmds/clone/result_clone.py
@@ -1,6 +1,5 @@
-from ...errors.path_cannot_be_file import PathCannotBeFile
 from ...errors.directory_not_empty import DirectoryNotEmpty
+from ...errors.path_cannot_be_file import PathCannotBeFile
 from ...errors.worktree_creation_err import WorktreeCreationErr
-
 
 CloneRepositoryErr = PathCannotBeFile | DirectoryNotEmpty | WorktreeCreationErr

--- a/src/cmds/config/cmd_config.py
+++ b/src/cmds/config/cmd_config.py
@@ -1,15 +1,12 @@
 import logging
 
-from result import Result, Ok, Err
-
-
-from .args_config import ConfigArgs
-from .result_config import ConfigError
+from result import Err, Ok, Result
 
 from ...errors.not_bare_repo_err import NotBareRepoErr
-
-from ...helpers.config_file import ensure_config_exists, read_config, write_config_file, set_list_value, get_list_value
+from ...helpers.config_file import ensure_config_exists, get_list_value, read_config, set_list_value, write_config_file
 from ...helpers.find_git import get_git_dir
+from .args_config import ConfigArgs
+from .result_config import ConfigError
 
 
 def configure(config_args: ConfigArgs) -> Result[None, ConfigError]:

--- a/src/cmds/config/result_config.py
+++ b/src/cmds/config/result_config.py
@@ -1,7 +1,6 @@
-from ...errors.not_bare_repo_err import NotBareRepoErr
+from ...errors.config_perm_err import ConfigPermErr
 from ...errors.config_read_err import ConfigReadErr
 from ...errors.config_write_err import ConfigWriteErr
-from ...errors.config_perm_err import ConfigPermErr
-
+from ...errors.not_bare_repo_err import NotBareRepoErr
 
 ConfigError = NotBareRepoErr | ConfigReadErr | ConfigWriteErr | ConfigPermErr

--- a/src/cmds/destroy/cmd_destroy.py
+++ b/src/cmds/destroy/cmd_destroy.py
@@ -1,18 +1,16 @@
 import logging
 import shutil
-import pygit2 as pg
-
 from pathlib import Path
-from result import Result, Ok, Err
 
-from .args_destroy import DestroyArgs
-from .result_destroy import DestroyRepoError
+import pygit2 as pg
+from result import Err, Ok, Result
 
 from ...errors.destroy_err import DestroyErr
 from ...errors.directory_not_found_err import DirectoryNotFoundErr
 from ...errors.not_bare_repo_err import NotBareRepoErr
-
 from ...helpers.config_file import remove_repo_entry
+from .args_destroy import DestroyArgs
+from .result_destroy import DestroyRepoError
 
 
 def destroy_repo(destroy_args: DestroyArgs) -> Result[None, DestroyRepoError]:

--- a/src/cmds/destroy/result_destroy.py
+++ b/src/cmds/destroy/result_destroy.py
@@ -1,9 +1,8 @@
-from ...errors.config_read_err import ConfigReadErr
 from ...errors.config_perm_err import ConfigPermErr
+from ...errors.config_read_err import ConfigReadErr
 from ...errors.config_write_err import ConfigWriteErr
 from ...errors.destroy_err import DestroyErr
 from ...errors.directory_not_found_err import DirectoryNotFoundErr
 from ...errors.not_bare_repo_err import NotBareRepoErr
-
 
 DestroyRepoError = NotBareRepoErr | DirectoryNotFoundErr | DestroyErr | ConfigReadErr | ConfigWriteErr | ConfigPermErr

--- a/src/cmds/rm/cmd_rm.py
+++ b/src/cmds/rm/cmd_rm.py
@@ -1,21 +1,18 @@
 import logging
 import shutil
-import pygit2 as pg
-
 from pathlib import Path
-from result import Result, Ok, Err
 
-
-from .args_rm import RmArgs
-from .result_rm import RemoveWorktreeError
+import pygit2 as pg
+from result import Err, Ok, Result
 
 from ...errors.not_bare_repo_err import NotBareRepoErr
 from ...errors.unmerged_changes_err import UnmergedChangesErr
 from ...errors.worktree_not_found_err import WorktreeNotFoundErr
 from ...errors.worktree_remove_err import WorktreeRemoveErr
-
 from ...helpers.config_file import ensure_config_exists, read_config, remove_repo_entry
 from ...helpers.find_git import get_git_dir
+from .args_rm import RmArgs
+from .result_rm import RemoveWorktreeError
 
 
 def remove_worktree(rm_args: RmArgs) -> Result[None, RemoveWorktreeError]:
@@ -71,7 +68,7 @@ def _remove_single(
 
     try:
         worktree: pg.Worktree = bare_repo.lookup_worktree(branch_name)
-    except (KeyError, pg.GitError ):
+    except (KeyError, pg.GitError):
         log.warning("Worktree not found; branch_name=%s", branch_name)
         return Err(WorktreeNotFoundErr())
 
@@ -84,10 +81,7 @@ def _remove_single(
     if not force:
         unmerged = _has_unmerged_commits(bare_repo, git_dir, branch_name)
         if unmerged:
-            log.error(
-                "Branch has commits not in default branch, refusing removal; branch=%s. Use --force to override.",
-                branch_name
-            )
+            log.error("Branch has commits not in default branch, refusing removal; branch=%s. Use --force to override.", branch_name)
             return Err(UnmergedChangesErr())
 
     log.debug("Removing worktree directory; path=%s", wt_path)

--- a/src/cmds/rm/result_rm.py
+++ b/src/cmds/rm/result_rm.py
@@ -1,10 +1,11 @@
-from ...errors.config_read_err import ConfigReadErr
 from ...errors.config_perm_err import ConfigPermErr
+from ...errors.config_read_err import ConfigReadErr
 from ...errors.config_write_err import ConfigWriteErr
 from ...errors.not_bare_repo_err import NotBareRepoErr
+from ...errors.unmerged_changes_err import UnmergedChangesErr
 from ...errors.worktree_not_found_err import WorktreeNotFoundErr
 from ...errors.worktree_remove_err import WorktreeRemoveErr
-from ...errors.unmerged_changes_err import UnmergedChangesErr
 
-
-RemoveWorktreeError = NotBareRepoErr | WorktreeNotFoundErr | WorktreeRemoveErr | ConfigReadErr | ConfigWriteErr | ConfigPermErr | UnmergedChangesErr
+RemoveWorktreeError = (
+    NotBareRepoErr | WorktreeNotFoundErr | WorktreeRemoveErr | ConfigReadErr | ConfigWriteErr | ConfigPermErr | UnmergedChangesErr
+)

--- a/src/errors/__init__.py
+++ b/src/errors/__init__.py
@@ -1,4 +1,4 @@
-from .not_bare_repo_err import NotBareRepoErr
-from .not_repo_err import NotRepoErr
-from .success import Success
-from .worktree_creation_err import WorktreeCreationErr
+from .not_bare_repo_err import NotBareRepoErr as NotBareRepoErr
+from .not_repo_err import NotRepoErr as NotRepoErr
+from .success import Success as Success
+from .worktree_creation_err import WorktreeCreationErr as WorktreeCreationErr

--- a/src/errors/no_fast_forward_merge.py
+++ b/src/errors/no_fast_forward_merge.py
@@ -1,3 +1,2 @@
 class NoFastForwardMerge:
     pass
-

--- a/src/exit_codes.py
+++ b/src/exit_codes.py
@@ -3,22 +3,22 @@ from enum import IntEnum
 
 class ExitCode(IntEnum):
     # Standard
-    SUCCESS          = 0
-    ERR_GENERAL      = 1
-    ERR_MISUSE       = 2    # Misuse of shell built-ins / bad arguments
-    ERR_NO_EXEC      = 126  # Command found but not executable
-    ERR_NOT_FOUND    = 127  # Command not found
+    SUCCESS = 0
+    ERR_GENERAL = 1
+    ERR_MISUSE = 2  # Misuse of shell built-ins / bad arguments
+    ERR_NO_EXEC = 126  # Command found but not executable
+    ERR_NOT_FOUND = 127  # Command not found
 
     # App-specific (166–254 range reserved for custom use)
-    ERR_PATH_IS_FILE    = 166  # Destination path is a file, expected directory
-    ERR_DIR_NOT_EMPTY   = 167  # Destination directory is not empty
-    ERR_NOT_BARE_REPO   = 168  # No bare git repository found
-    ERR_WORKTREE        = 169  # Worktree creation failed
-    ERR_BRANCH_MISSING  = 170  # Derived branch does not exist
-    ERR_NO_FF_MERGE     = 171  # Branch requires true merge, cannot fast-forward
-    ERR_CONFIG_READ     = 172  # Failed to read config file
-    ERR_CONFIG_WRITE    = 173  # Failed to write config file
-    ERR_CONFIG_PERM     = 174  # Insufficient permissions on config file
-    ERR_UNMERGED        = 175  # Branch has commits not present in default branch
-    ERR_WORKTREE_MISSING = 176 # Worktree or branch not found
-    ERR_DIR_NOT_FOUND    = 177 # Directory does not exist
+    ERR_PATH_IS_FILE = 166  # Destination path is a file, expected directory
+    ERR_DIR_NOT_EMPTY = 167  # Destination directory is not empty
+    ERR_NOT_BARE_REPO = 168  # No bare git repository found
+    ERR_WORKTREE = 169  # Worktree creation failed
+    ERR_BRANCH_MISSING = 170  # Derived branch does not exist
+    ERR_NO_FF_MERGE = 171  # Branch requires true merge, cannot fast-forward
+    ERR_CONFIG_READ = 172  # Failed to read config file
+    ERR_CONFIG_WRITE = 173  # Failed to write config file
+    ERR_CONFIG_PERM = 174  # Insufficient permissions on config file
+    ERR_UNMERGED = 175  # Branch has commits not present in default branch
+    ERR_WORKTREE_MISSING = 176  # Worktree or branch not found
+    ERR_DIR_NOT_FOUND = 177  # Directory does not exist

--- a/src/helpers/auth_agent_callback.py
+++ b/src/helpers/auth_agent_callback.py
@@ -1,12 +1,13 @@
 import logging
 from typing import final, override
+
 from pygit2 import CredentialType, KeypairFromAgent, RemoteCallbacks
 from pygit2.remotes import TransferProgress
 from rich.progress import Progress
 
 from ..errors.git_auth_error import GitAuthError
-
 from .logger import console
+
 
 @final
 class AuthAgentCallback(RemoteCallbacks):
@@ -43,15 +44,6 @@ class AuthAgentCallback(RemoteCallbacks):
             return
 
         if self._task is None:
-            self._task = self._progress.add_task(
-                description="",
-                total=stats.total_objects,
-                completed=stats.indexed_objects
-            )
+            self._task = self._progress.add_task(description="", total=stats.total_objects, completed=stats.indexed_objects)
 
-        self._progress.update(
-            self._task,
-            description=None,
-            completed=stats.indexed_objects,
-            refresh=True
-        )
+        self._progress.update(self._task, description=None, completed=stats.indexed_objects, refresh=True)

--- a/src/helpers/config_file.py
+++ b/src/helpers/config_file.py
@@ -1,14 +1,13 @@
 import configparser
 import logging
 import os
-
 from pathlib import Path
+
 from result import Err, Ok, Result
 
+from ..errors.config_perm_err import ConfigPermErr
 from ..errors.config_read_err import ConfigReadErr
 from ..errors.config_write_err import ConfigWriteErr
-from ..errors.config_perm_err import ConfigPermErr
-
 
 CONFIG_PATH = Path.home() / ".gitconfig_wt"
 
@@ -75,7 +74,7 @@ def write_config_file(config: configparser.RawConfigParser, path: Path) -> Resul
     log = logging.getLogger(__name__)
 
     try:
-        with open(path, 'w') as f:
+        with open(path, "w") as f:
             for section in config.sections():
                 _ = f.write(f"[{section}]\n")
 
@@ -146,8 +145,8 @@ def ensure_repo_entry(repo_path: Path) -> Result[None, ConfigReadErr | ConfigWri
         case Ok(config):
             pass
 
-    if not config.has_section(str( repo_path.absolute() )):
-        config.add_section(str( repo_path.absolute() ))
+    if not config.has_section(str(repo_path.absolute())):
+        config.add_section(str(repo_path.absolute()))
         return write_config_file(config, config_path)
 
     return Ok(None)

--- a/src/helpers/find_git.py
+++ b/src/helpers/find_git.py
@@ -7,20 +7,14 @@ def get_git_dir(start: str) -> str | None:
 
     # If git is a file, then we're in a branch of the worktree
     if git.is_file():
-        return str( path.parent )
+        return str(path.parent)
 
     # If git is a dir, then we're not in a bare repo
     if git.is_dir():
         return None
 
     # If at least 3 are present, then we're in the bare repo's root
-    bare_root_dic = {
-        'config': False,
-        'HEAD': False,
-        'packed-refs': False,
-        'objects': False,
-        'FETCH_HEAD': False
-    }
+    bare_root_dic = {"config": False, "HEAD": False, "packed-refs": False, "objects": False, "FETCH_HEAD": False}
 
     for dir in path.iterdir():
         if dir.name in bare_root_dic:
@@ -28,7 +22,6 @@ def get_git_dir(start: str) -> str | None:
 
     contains_git_files: bool = sum(bare_root_dic.values()) >= 3
     if contains_git_files:
-        return str( path.absolute() )
+        return str(path.absolute())
     else:
         return None
-

--- a/src/helpers/logger.py
+++ b/src/helpers/logger.py
@@ -1,12 +1,12 @@
 import os
-
 from logging import basicConfig
+
 import click
 from rich.console import Console
 from rich.logging import RichHandler
 
+console = Console(stderr=True)  # Shared
 
-console = Console(stderr=True) # Shared
 
 def setup_logging() -> None:
     level = os.getenv("LOG_LEVEL", "INFO").upper()
@@ -27,5 +27,5 @@ def setup_logging() -> None:
                 tracebacks_show_locals=True,
                 tracebacks_suppress=[click],
             )
-        ]
+        ],
     )

--- a/src/main.py
+++ b/src/main.py
@@ -1,43 +1,37 @@
-import os
-import click
 import logging
-
+import os
 from pathlib import Path
+
+import click
 from result import Err, Ok
 
-from .errors.path_cannot_be_file import PathCannotBeFile
-from .errors.directory_not_empty import DirectoryNotEmpty
-from .errors.derived_branch_does_not_exist import DeriveBranchDoesNotExist
-from .errors.no_fast_forward_merge import NoFastForwardMerge
-from .errors.not_bare_repo_err import NotBareRepoErr
-from .errors.worktree_creation_err import WorktreeCreationErr
+from .cmds.add.args_add import AddArgs
+from .cmds.add.cmd_add import add_worktree
+from .cmds.clone.args_clone import CloneArgs
+from .cmds.clone.cmd_clone import clone_repository
+from .cmds.config.args_config import ConfigArgs
+from .cmds.config.cmd_config import configure
+from .cmds.destroy.args_destroy import DestroyArgs
+from .cmds.destroy.cmd_destroy import destroy_repo
+from .cmds.rm.args_rm import RmArgs
+from .cmds.rm.cmd_rm import remove_worktree
+from .errors.config_perm_err import ConfigPermErr
 from .errors.config_read_err import ConfigReadErr
 from .errors.config_write_err import ConfigWriteErr
-from .errors.config_perm_err import ConfigPermErr
+from .errors.derived_branch_does_not_exist import DeriveBranchDoesNotExist
+from .errors.destroy_err import DestroyErr
+from .errors.directory_not_empty import DirectoryNotEmpty
+from .errors.directory_not_found_err import DirectoryNotFoundErr
+from .errors.no_fast_forward_merge import NoFastForwardMerge
+from .errors.not_bare_repo_err import NotBareRepoErr
+from .errors.path_cannot_be_file import PathCannotBeFile
 from .errors.unmerged_changes_err import UnmergedChangesErr
+from .errors.worktree_creation_err import WorktreeCreationErr
 from .errors.worktree_not_found_err import WorktreeNotFoundErr
 from .errors.worktree_remove_err import WorktreeRemoveErr
-from .errors.directory_not_found_err import DirectoryNotFoundErr
-from .errors.destroy_err import DestroyErr
-
 from .exit_codes import ExitCode
-from .helpers.logger import setup_logging
 from .helpers.config_file import ensure_repo_entry
-
-from .cmds.add.cmd_add import add_worktree
-from .cmds.add.args_add import AddArgs
-
-from .cmds.clone.cmd_clone import clone_repository
-from .cmds.clone.args_clone import CloneArgs
-
-from .cmds.config.cmd_config import configure
-from .cmds.config.args_config import ConfigArgs
-
-from .cmds.rm.cmd_rm import remove_worktree
-from .cmds.rm.args_rm import RmArgs
-
-from .cmds.destroy.cmd_destroy import destroy_repo
-from .cmds.destroy.args_destroy import DestroyArgs
+from .helpers.logger import setup_logging
 
 
 @click.group()
@@ -51,14 +45,20 @@ def cli():
 @click.argument("NEW_BRANCH_NAME", type=str)
 @click.argument("DERIVE_FROM_BRANCH", type=str, required=False)
 @click.option("--force", "-f", is_flag=True, default=False, help="Force checkout, even if branch already exists locally")
-@click.option("--exclude", "-e", type=str, default=[], help="""
+@click.option(
+    "--exclude",
+    "-e",
+    type=str,
+    default=[],
+    help="""
 Exclude files from being copied over. Provide a comma-seperated list
 
 Example: `--exclude="node_modules,dist,target,bin"`
 
 WARNING: This can override the config file
-""")
-def add(new_branch_name: str, derive_from_branch: str, exclude: list[str]=[], force: bool=False):
+""",
+)
+def add(new_branch_name: str, derive_from_branch: str, exclude: list[str] | None = None, force: bool = False):
     """
     Create a worktree
 
@@ -71,13 +71,7 @@ def add(new_branch_name: str, derive_from_branch: str, exclude: list[str]=[], fo
     should_nest_dirs: bool = False
     exclude_files_from_copy: list[str] = exclude or []
 
-    add_args: AddArgs = AddArgs(
-        new_branch_name,
-        derive_from_branch,
-        should_nest_dirs,
-        exclude_files_from_copy,
-        force
-    )
+    add_args: AddArgs = AddArgs(new_branch_name, derive_from_branch, should_nest_dirs, exclude_files_from_copy, force)
 
     worktree_creaton_res = add_worktree(add_args)
 
@@ -116,27 +110,27 @@ def add(new_branch_name: str, derive_from_branch: str, exclude: list[str]=[], fo
     type=str,
     multiple=True,
     metavar="<CMD>",
-    help="Command to run after successful worktree creation. Can be repeated for multiple commands. Automatically ran after `git wt add`.")
+    help="Command to run after successful worktree creation. Can be repeated for multiple commands. Automatically ran after `git wt add`.",
+)
 @click.option(
     "--remove-command",
     type=str,
     multiple=True,
     metavar="<CMD>",
-    help="Command to run after successful worktree removal. Can be repeated for multiple commands. Automatically ran after `git wt rm`.")
+    help="Command to run after successful worktree removal. Can be repeated for multiple commands. Automatically ran after `git wt rm`.",
+)
 @click.option(
-    "--exclude", "-e",
+    "--exclude",
+    "-e",
     type=str,
     multiple=True,
     metavar="<GLOB>",
-    help="Glob pattern of files to exclude when copying after worktree creation. Can be repeated to specify multiple patterns.")
+    help="Glob pattern of files to exclude when copying after worktree creation. Can be repeated to specify multiple patterns.",
+)
+@click.option("--default-branch", type=str, default="", metavar="<BRANCH>", help="Default branch name to derive new worktrees from.")
 @click.option(
-    "--default-branch",
-    type=str,
-    default="",
-    metavar="<BRANCH>",
-    help="Default branch name to derive new worktrees from.")
-@click.option(
-    "--list", "-l",
+    "--list",
+    "-l",
     is_flag=True,
     default=False,
     help="""
@@ -147,7 +141,8 @@ def add(new_branch_name: str, derive_from_branch: str, exclude: list[str]=[], fo
         Example: ["node_modules", "cache"]
 
         The `git wt add` wouldn't need `--exclude "node_modules" --exclude "cache"` every time it's ran in the configured repo.
-    """)
+    """,
+)
 def config(add_command: tuple[str, ...], remove_command: tuple[str, ...], exclude: tuple[str, ...], default_branch: str, list: bool):
     log = logging.getLogger(__name__)
 
@@ -157,7 +152,7 @@ def config(add_command: tuple[str, ...], remove_command: tuple[str, ...], exclud
         remove_commands=remove_command,
         copy_exclude=exclude,
         default_branch_name=default_branch,
-        list=list
+        list=list,
     )
 
     config_res = configure(config_args)
@@ -229,10 +224,7 @@ def clone(repository: str, directory: str):
         case Ok(_):
             pass
 
-    clone_args: CloneArgs = CloneArgs(
-        repository_link=repository,
-        dest=dest
-    )
+    clone_args: CloneArgs = CloneArgs(repository_link=repository, dest=dest)
 
     clone_res = clone_repository(clone_args)
 
@@ -268,11 +260,7 @@ def rm(branch_names: tuple[str, ...], force: bool):
 
     log = logging.getLogger(__name__)
 
-    rm_args: RmArgs = RmArgs(
-        branch_names=branch_names,
-        current_working_dir=os.getcwd(),
-        force=force
-    )
+    rm_args: RmArgs = RmArgs(branch_names=branch_names, current_working_dir=os.getcwd(), force=force)
 
     rm_res = remove_worktree(rm_args)
 
@@ -333,10 +321,7 @@ def destroy(directory: str, force: bool):
     if not force:
         _ = click.confirm(f"This will permanently delete '{directory}' and all its contents. Continue?", abort=True)
 
-    destroy_args: DestroyArgs = DestroyArgs(
-        directory=directory,
-        force=force
-    )
+    destroy_args: DestroyArgs = DestroyArgs(directory=directory, force=force)
 
     destroy_res = destroy_repo(destroy_args)
 
@@ -394,4 +379,3 @@ def switch():
 
 if __name__ == "__main__":
     cli()
-


### PR DESCRIPTION
## Summary

- Add GitHub Actions CI pipeline: lint (ruff), build verification, test stage
- Add ruff config to pyproject.toml (pycodestyle, pyflakes, isort, pyupgrade, bugbear, simplify)
- Add pre-commit hook: ruff format + lint check on staged .py files
- Add commit-msg hook: conventional commit format validation (72 char max)
- Format entire codebase with ruff, fix import sorting and mutable default arg bug

## Test plan

- [x] `ruff check src/` passes clean
- [x] `ruff format --check src/` passes clean
- [x] `pip install .` + `git-wt --version` verified in isolated venv
- [x] Pre-commit hook tested (fires on commit, blocks on lint failure)
- [x] Commit-msg hook tested (rejects >72 char subject)
- [ ] GitHub Actions pipeline runs on PR

**Note:** Activate hooks with `git config core.hooksPath .githooks`