### PR TITLE
feat(pull): implement git wt pull command

### DIFF
--- a/src/cmds/pull/args_pull.py
+++ b/src/cmds/pull/args_pull.py
@@ -1,0 +1,7 @@
+from dataclasses import dataclass
+
+
+@dataclass()
+class PullArgs:
+    branch_name: str
+    current_working_dir: str

--- a/src/cmds/pull/cmd_pull.py
+++ b/src/cmds/pull/cmd_pull.py
@@ -1,0 +1,80 @@
+import logging
+from pathlib import Path
+
+import pygit2 as pg
+from result import Err, Ok, Result
+
+from ...errors.fetch_err import FetchErr
+from ...errors.not_bare_repo_err import NotBareRepoErr
+from ...errors.remote_branch_not_found_err import RemoteBranchNotFoundErr
+from ...errors.worktree_already_exists import WorktreeAlreadyExistsErr
+from ...errors.worktree_creation_err import WorktreeCreationErr
+from ...helpers.auth_agent_callback import AuthAgentCallback
+from ...helpers.find_git import get_git_dir
+from .args_pull import PullArgs
+from .result_pull import PullWorktreeErr
+
+
+def pull_worktree(pull_args: PullArgs) -> Result[None, PullWorktreeErr]:
+    log = logging.getLogger(__name__)
+
+    sanitized_branch_name: str = pull_args.branch_name.replace("/", "-")
+    current_path: str = pull_args.current_working_dir
+
+    log.debug(
+        "Attempting to pull worktree; branch_name=%s, sanitized_branch_name=%s, current_path=%s",
+        pull_args.branch_name,
+        sanitized_branch_name,
+        current_path,
+    )
+
+    git_dir = get_git_dir(current_path)
+    if not git_dir:
+        log.warning("This isn't a bare git repository; branch_name=%s, current_path=%s", pull_args.branch_name, current_path)
+        return Err(NotBareRepoErr())
+
+    log.info("Git repository found; git_dir=%s", git_dir)
+    bare_repo: pg.Repository = pg.Repository(git_dir, flags=pg.enums.RepositoryOpenFlag.BARE)
+
+    log.debug("Repository opened; repository=%s", bare_repo)
+
+    if not bare_repo.is_bare:
+        log.warning("This isn't a bare git repository; branch_name=%s, current_path=%s", pull_args.branch_name, current_path)
+        return Err(NotBareRepoErr())
+
+    try:
+        log.debug("Fetching branch from origin; branch_name=%s", pull_args.branch_name)
+        remote: pg.Remote = bare_repo.remotes["origin"]
+        _ = remote.fetch(refspecs=[f"refs/heads/{pull_args.branch_name}:refs/heads/{pull_args.branch_name}"], callbacks=AuthAgentCallback())
+        log.info("Fetched branch from origin; branch_name=%s", pull_args.branch_name)
+    except (KeyError, pg.GitError) as e:
+        log.error("Failed to fetch from origin; branch_name=%s, error=%s", pull_args.branch_name, e)
+        return Err(FetchErr())
+
+    try:
+        branch_ref: pg.Reference = bare_repo.lookup_reference(f"refs/heads/{pull_args.branch_name}")
+        log.debug("Branch ref resolved; branch_name=%s, target=%s", pull_args.branch_name, branch_ref.target)
+    except (KeyError, pg.GitError) as e:
+        log.error("Branch not found after fetch; branch_name=%s, error=%s", pull_args.branch_name, e)
+        return Err(RemoteBranchNotFoundErr())
+
+    wt_path: Path = Path(git_dir, sanitized_branch_name).absolute()
+
+    log.debug("Preparing to create worktree; worktree_path=%s, worktree_name=%s, repository=%s", wt_path, sanitized_branch_name, bare_repo)
+
+    try:
+        new_worktree: pg.Worktree = bare_repo.add_worktree(sanitized_branch_name, str(wt_path), branch_ref)
+        log.info("Successfully created a worktree; worktree_name=%s, branch_name=%s", new_worktree.name, pull_args.branch_name)
+    except OSError:
+        log.error("Worktree creation failed; worktree_path=%s, worktree_name=%s, repository=%s", wt_path, sanitized_branch_name, bare_repo)
+        return Err(WorktreeCreationErr())
+    except pg.AlreadyExistsError:
+        log.error(
+            "Worktree with the same name already exists; worktree_path=%s, worktree_name=%s, repository=%s",
+            wt_path,
+            sanitized_branch_name,
+            bare_repo,
+        )
+        return Err(WorktreeAlreadyExistsErr())
+
+    return Ok(None)

--- a/src/cmds/pull/result_pull.py
+++ b/src/cmds/pull/result_pull.py
@@ -1,0 +1,7 @@
+from ...errors.fetch_err import FetchErr
+from ...errors.not_bare_repo_err import NotBareRepoErr
+from ...errors.remote_branch_not_found_err import RemoteBranchNotFoundErr
+from ...errors.worktree_already_exists import WorktreeAlreadyExistsErr
+from ...errors.worktree_creation_err import WorktreeCreationErr
+
+PullWorktreeErr = NotBareRepoErr | WorktreeCreationErr | WorktreeAlreadyExistsErr | RemoteBranchNotFoundErr | FetchErr

--- a/src/errors/__init__.py
+++ b/src/errors/__init__.py
@@ -1,4 +1,6 @@
+from .fetch_err import FetchErr as FetchErr
 from .not_bare_repo_err import NotBareRepoErr as NotBareRepoErr
 from .not_repo_err import NotRepoErr as NotRepoErr
+from .remote_branch_not_found_err import RemoteBranchNotFoundErr as RemoteBranchNotFoundErr
 from .success import Success as Success
 from .worktree_creation_err import WorktreeCreationErr as WorktreeCreationErr

--- a/src/errors/fetch_err.py
+++ b/src/errors/fetch_err.py
@@ -1,0 +1,2 @@
+class FetchErr:
+    pass

--- a/src/errors/remote_branch_not_found_err.py
+++ b/src/errors/remote_branch_not_found_err.py
@@ -1,0 +1,2 @@
+class RemoteBranchNotFoundErr:
+    pass

--- a/src/exit_codes.py
+++ b/src/exit_codes.py
@@ -22,3 +22,5 @@ class ExitCode(IntEnum):
     ERR_UNMERGED = 175  # Branch has commits not present in default branch
     ERR_WORKTREE_MISSING = 176  # Worktree or branch not found
     ERR_DIR_NOT_FOUND = 177  # Directory does not exist
+    ERR_REMOTE_BRANCH_NOT_FOUND = 178  # Remote branch does not exist
+    ERR_FETCH = 179  # Failed to fetch from remote

--- a/src/main.py
+++ b/src/main.py
@@ -13,6 +13,8 @@ from .cmds.config.args_config import ConfigArgs
 from .cmds.config.cmd_config import configure
 from .cmds.destroy.args_destroy import DestroyArgs
 from .cmds.destroy.cmd_destroy import destroy_repo
+from .cmds.pull.args_pull import PullArgs
+from .cmds.pull.cmd_pull import pull_worktree
 from .cmds.rm.args_rm import RmArgs
 from .cmds.rm.cmd_rm import remove_worktree
 from .errors.config_perm_err import ConfigPermErr
@@ -22,10 +24,13 @@ from .errors.derived_branch_does_not_exist import DeriveBranchDoesNotExist
 from .errors.destroy_err import DestroyErr
 from .errors.directory_not_empty import DirectoryNotEmpty
 from .errors.directory_not_found_err import DirectoryNotFoundErr
+from .errors.fetch_err import FetchErr
 from .errors.no_fast_forward_merge import NoFastForwardMerge
 from .errors.not_bare_repo_err import NotBareRepoErr
 from .errors.path_cannot_be_file import PathCannotBeFile
+from .errors.remote_branch_not_found_err import RemoteBranchNotFoundErr
 from .errors.unmerged_changes_err import UnmergedChangesErr
+from .errors.worktree_already_exists import WorktreeAlreadyExistsErr
 from .errors.worktree_creation_err import WorktreeCreationErr
 from .errors.worktree_not_found_err import WorktreeNotFoundErr
 from .errors.worktree_remove_err import WorktreeRemoveErr
@@ -400,6 +405,55 @@ def destroy(directory: str, force: bool):
 
         case Ok(None):
             log.info("Bare repository destroyed successfully; directory=%s", directory)
+            exit(ExitCode.SUCCESS)
+
+
+@cli.command()
+@click.argument("BRANCH_NAME", type=str)
+def pull(branch_name: str):
+    """
+    Pull a branch from origin and create a worktree for it.
+
+    Fetches BRANCH_NAME from origin, then creates a new worktree at
+    <bare_repo>/<sanitized_branch_name>. Slashes(`/`) in the branch name
+    will be replaced with dash(`-`) to avoid directory nesting.
+    """
+
+    log = logging.getLogger(__name__)
+
+    pull_args: PullArgs = PullArgs(branch_name=branch_name, current_working_dir=os.getcwd())
+
+    pull_res = pull_worktree(pull_args)
+
+    log.debug("Worktree pull result; result=%s", pull_res)
+
+    match pull_res:
+        case Err(NotBareRepoErr()):
+            log.error("Cannot find a BARE git repository in the current working directory.")
+            exit(ExitCode.ERR_NOT_BARE_REPO)
+
+        case Err(WorktreeCreationErr()):
+            log.error("An error occurred while trying to create the new worktree. Please, try again.")
+            exit(ExitCode.ERR_WORKTREE)
+
+        case Err(WorktreeAlreadyExistsErr()):
+            log.error("A worktree for this branch already exists locally.")
+            exit(ExitCode.ERR_WORKTREE)
+
+        case Err(RemoteBranchNotFoundErr()):
+            log.error("The branch does not exist on the remote repository.")
+            exit(ExitCode.ERR_REMOTE_BRANCH_NOT_FOUND)
+
+        case Err(FetchErr()):
+            log.error("Failed to fetch the branch from the remote repository.")
+            exit(ExitCode.ERR_FETCH)
+
+        case Err(_):
+            log.fatal("Something has gone horribly wrong. Aborting immediately!")
+            exit(ExitCode.ERR_GENERAL)
+
+        case Ok(None):
+            log.info("Successfully pulled branch and created worktree; branch_name=%s", branch_name)
             exit(ExitCode.SUCCESS)
 
 


### PR DESCRIPTION
Adds `git wt pull <BRANCH_NAME>` — fetches a branch from origin and creates a local worktree in one step.

**What changed**
- `src/cmds/pull/` — new three-file command module
- `src/errors/fetch_err.py`, `src/errors/remote_branch_not_found_err.py` — two new error types
- `src/exit_codes.py` — `ERR_REMOTE_BRANCH_NOT_FOUND = 178`, `ERR_FETCH = 179`
- `src/errors/__init__.py`, `src/main.py` — wired up

**Behaviour**
1. Validates CWD is inside a bare repo
2. Fetches branch from origin via SSH agent
3. Resolves the fetched ref; errors if not found after fetch
4. Creates worktree at `<bare_root>/<sanitized_branch_name>` (slashes → dashes)