### PR TITLE
chore: add ruff dev dependency and config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
 dev = [
     "pytest>=8.0",
     "pytest-cov",
+    "ruff>=0.8",
 ]
 
 [project.scripts]
@@ -32,5 +33,23 @@ packages = ["src"]
 testpaths = ["tests"]
 pythonpath = ["."]
 
-# [tool.mypy]
-# plugins = ["returns.contrib.mypy.returns_plugin"]
+[tool.ruff]
+target-version = "py311"
+line-length = 140
+
+[tool.ruff.lint]
+select = [
+    "E",    # pycodestyle errors
+    "W",    # pycodestyle warnings
+    "F",    # pyflakes
+    "I",    # isort
+    "UP",   # pyupgrade
+    "B",    # flake8-bugbear
+    "SIM",  # flake8-simplify
+]
+ignore = [
+    "E501",  # line too long (handled by formatter with line-length above)
+]
+
+[tool.ruff.format]
+quote-style = "double"


### PR DESCRIPTION
## Summary

Add `ruff>=0.8` to dev dependencies and configure ruff in `pyproject.toml`.

- `[tool.ruff]`: target Python 3.11, 140-char line length
- `[tool.ruff.lint]`: enable pycodestyle (E/W), pyflakes (F), isort (I), pyupgrade (UP), bugbear (B), simplify (SIM)
- `[tool.ruff.format]`: double-quote style
- Remove stale commented-out mypy block

## Merge order

This is **#1 of 5** split from #3. Merge before `chore/ruff-format-src` (which applies the formatter using this config).

## Files changed

- `pyproject.toml`