### PR TITLE
chore: format codebase with ruff

### DIFF
--- a/src/cmds/add/cmd_add.py
+++ b/src/cmds/add/cmd_add.py
@@ -1,50 +1,73 @@
-from fnmatch import fnmatch
 import logging
 import os
-import pygit2 as pg
-
-from result import Result, Ok, Err
-from shutil import copy2, copytree
+from fnmatch import fnmatch
 from pathlib import Path
+
+import pygit2 as pg
+from result import Err, Ok, Result
+from shutil import copy2, copytree
 
 from .args_add import AddArgs
 from .result_add import AddWorktreeError
-
-from ...errors.no_fast_forward_merge import NoFastForwardMerge
-from ...errors.worktree_already_exists import WorktreeAlreadyExistsErr
 from ...errors.derived_branch_does_not_exist import DeriveBranchDoesNotExist
-from ...helpers.find_git import get_git_dir
+from ...errors.no_fast_forward_merge import NoFastForwardMerge
 from ...errors.not_bare_repo_err import NotBareRepoErr
+from ...errors.worktree_already_exists import WorktreeAlreadyExistsErr
 from ...errors.worktree_creation_err import WorktreeCreationErr
+from ...helpers.find_git import get_git_dir
 
 
 def add_worktree(add_args: AddArgs) -> Result[None, AddWorktreeError]:
     log = logging.getLogger(__name__)
 
-    branch_name: str = add_args.new_branch_name if add_args.should_nest_dirs else add_args.new_branch_name.replace('/', '-')
+    branch_name: str = (
+        add_args.new_branch_name
+        if add_args.should_nest_dirs
+        else add_args.new_branch_name.replace("/", "-")
+    )
     current_path: str = os.getcwd()
 
-    log.debug("Attempting to find git dir; should_nest_dirs=%s, branch_path=%s, current_path=%s", add_args.should_nest_dirs, branch_name, current_path)
+    log.debug(
+        "Attempting to find git dir; should_nest_dirs=%s, branch_path=%s, current_path=%s",
+        add_args.should_nest_dirs,
+        branch_name,
+        current_path,
+    )
 
     git_dir = get_git_dir(current_path)
     if not git_dir:
-        log.warning("This isn't a bare git repository; should_nest_dirs=%s, branch_path=%s, current_path=%s", add_args.should_nest_dirs, branch_name, current_path)
+        log.warning(
+            "This isn't a bare git repository; should_nest_dirs=%s, branch_path=%s, current_path=%s",
+            add_args.should_nest_dirs,
+            branch_name,
+            current_path,
+        )
         return Err(NotBareRepoErr())
 
     derived_branch_exists: Path = Path(git_dir, add_args.derive_from_branch)
     if not derived_branch_exists.exists(follow_symlinks=True):
-        log.warning("Derived branch does not exist; derived_branch_path=%s", str( derived_branch_exists.absolute ))
+        log.warning(
+            "Derived branch does not exist; derived_branch_path=%s",
+            str(derived_branch_exists.absolute),
+        )
         return Err(DeriveBranchDoesNotExist())
 
     # TODO: Specify the repo to be based on the derived_branch
     log.info("Git repository found; git_dir=%s", git_dir)
-    bare_repo: pg.Repository = pg.Repository(git_dir, flags=pg.enums.RepositoryOpenFlag.BARE)
+    bare_repo: pg.Repository = pg.Repository(
+        git_dir, flags=pg.enums.RepositoryOpenFlag.BARE
+    )
 
     log.debug("Repository opened; repository=%s", bare_repo)
 
     # Technically shouldn't be hittable, as get_git_dir checks for that
     if not bare_repo.is_bare:
-        log.warning("This isn't a bare git repository; should_nest_dirs=%s, branch_path=%s, current_path=%s", add_args.should_nest_dirs, branch_name, current_path)
+        log.warning(
+            "This isn't a bare git repository; should_nest_dirs=%s, branch_path=%s, current_path=%s",
+            add_args.should_nest_dirs,
+            branch_name,
+            current_path,
+        )
         return Err(NotBareRepoErr())
 
     # TODO: Check if this fetches main branch, if configured
@@ -53,19 +76,30 @@ def add_worktree(add_args: AddArgs) -> Result[None, AddWorktreeError]:
     #
     # log.info("Fetched commits from origin; num_fetched_commits=%s", transfer_progress.total_deltas)
 
-    remote_branch = bare_repo.lookup_reference(f"refs/heads/{add_args.derive_from_branch}").peel(pg.Commit)
+    remote_branch = bare_repo.lookup_reference(
+        f"refs/heads/{add_args.derive_from_branch}"
+    ).peel(pg.Commit)
     analysis, _ = bare_repo.merge_analysis(remote_branch.id)
 
-    log.debug("Derived branch info; derive_branch_ref=%s, analysis=%s", remote_branch.id, analysis)
+    log.debug(
+        "Derived branch info; derive_branch_ref=%s, analysis=%s",
+        remote_branch.id,
+        analysis,
+    )
 
     if analysis & pg.GIT_MERGE_ANALYSIS_UP_TO_DATE:
-        log.info("Derived branch already up to date; derive_from_branch=%s", add_args.derive_from_branch)
+        log.info(
+            "Derived branch already up to date; derive_from_branch=%s",
+            add_args.derive_from_branch,
+        )
 
     elif analysis & pg.GIT_MERGE_ANALYSIS_FASTFORWARD:
         # NOTE: Untested!
         # Move HEAD and working tree forward
         _ = bare_repo.checkout_tree(treeish=bare_repo.get(remote_branch.id))  # pyright: ignore[reportUnknownMemberType]
-        bare_repo.lookup_reference(f"refs/heads/{add_args.derive_from_branch}").set_target(remote_branch.id)
+        bare_repo.lookup_reference(
+            f"refs/heads/{add_args.derive_from_branch}"
+        ).set_target(remote_branch.id)
         bare_repo.head.set_target(remote_branch.id)
 
         log.info("Fast-forwarded ref branch; fast_forwarded=%s", remote_branch.id)
@@ -74,43 +108,86 @@ def add_worktree(add_args: AddArgs) -> Result[None, AddWorktreeError]:
         # True merge required — pygit2 can do it but you'd need to handle conflicts
         return Err(NoFastForwardMerge())
 
-
     new_worktree: pg.Worktree | None = None
     wt_path = Path(git_dir, branch_name).absolute()
 
-    log.debug("Preparing to create worktree; worktree_path=%s, worktree_name=%s, repository=%s", wt_path, branch_name, bare_repo)
+    log.debug(
+        "Preparing to create worktree; worktree_path=%s, worktree_name=%s, repository=%s",
+        wt_path,
+        branch_name,
+        bare_repo,
+    )
 
     try:
         new_worktree = bare_repo.add_worktree(branch_name, wt_path)
 
-        log.info("Successfully created a worktree; worktree_name=%s, branch_name=%s", new_worktree.name, branch_name)
+        log.info(
+            "Successfully created a worktree; worktree_name=%s, branch_name=%s",
+            new_worktree.name,
+            branch_name,
+        )
 
     except OSError:
-        log.error("Worktree opening failed; worktree_path=%s, worktree_name=%s, repository=%s", wt_path, branch_name, bare_repo)
+        log.error(
+            "Worktree opening failed; worktree_path=%s, worktree_name=%s, repository=%s",
+            wt_path,
+            branch_name,
+            bare_repo,
+        )
 
         return Err(WorktreeCreationErr())
 
     except pg.AlreadyExistsError:
-        log.error("Worktree with the same name already exists; worktree_path=%s, worktree_name=%s, repository=%s", wt_path, branch_name, bare_repo)
+        log.error(
+            "Worktree with the same name already exists; worktree_path=%s, worktree_name=%s, repository=%s",
+            wt_path,
+            branch_name,
+            bare_repo,
+        )
 
         return Err(WorktreeAlreadyExistsErr())
 
-
-    assert new_worktree is not None, "The new worktree must be created. Something wasn not handled correctly"
-    assert new_worktree.name == branch_name, "Worktree name must equal to the branch name provided"
-    assert new_worktree.path == str(wt_path), "The path of the worktree must be the same as the given path for worktree creation"
-
+    assert new_worktree is not None, (
+        "The new worktree must be created. Something wasn not handled correctly"
+    )
+    assert new_worktree.name == branch_name, (
+        "Worktree name must equal to the branch name provided"
+    )
+    assert new_worktree.path == str(wt_path), (
+        "The path of the worktree must be the same as the given path for worktree creation"
+    )
 
     derive_branch_path: Path = Path(git_dir, add_args.derive_from_branch)
-    log.info("Preparing for file copying; copy_from=%s, copy_to=%s", str( derive_branch_path ), new_worktree.path)
+    log.info(
+        "Preparing for file copying; copy_from=%s, copy_to=%s",
+        str(derive_branch_path),
+        new_worktree.path,
+    )
 
     derived_repo = pg.Repository(derive_branch_path)
-    log.debug("Derived repository opened; derived_repository=%s; derived_repo_workdir=%s", derived_repo, derived_repo.workdir)
+    log.debug(
+        "Derived repository opened; derived_repository=%s; derived_repo_workdir=%s",
+        derived_repo,
+        derived_repo.workdir,
+    )
 
-    git_ignored_files = [Path(derived_repo.workdir, ignored) for ignored in derived_repo.status(untracked_files="no", ignored=True)]
-    git_ignored_filtered_files = [ignored_file for ignored_file in git_ignored_files if not any(fnmatch(ignored_file.name, excluded_glob) for excluded_glob in add_args.exclude)]
+    git_ignored_files = [
+        Path(derived_repo.workdir, ignored)
+        for ignored in derived_repo.status(untracked_files="no", ignored=True)
+    ]
+    git_ignored_filtered_files = [
+        ignored_file
+        for ignored_file in git_ignored_files
+        if not any(
+            fnmatch(ignored_file.name, excluded_glob)
+            for excluded_glob in add_args.exclude
+        )
+    ]
 
-    log.debug("Found git ignored files from derived branch; git_ignored_files=%s", git_ignored_filtered_files)
+    log.debug(
+        "Found git ignored files from derived branch; git_ignored_files=%s",
+        git_ignored_filtered_files,
+    )
 
     try:
         for path in git_ignored_filtered_files:
@@ -120,10 +197,14 @@ def add_worktree(add_args: AddArgs) -> Result[None, AddWorktreeError]:
                 cp_res = copy2(str(path), new_worktree.path, follow_symlinks=True)
 
             elif path.is_dir():
-                cp_res = copytree(str(path), new_worktree.path, symlinks=True, dirs_exist_ok=True)
+                cp_res = copytree(
+                    str(path), new_worktree.path, symlinks=True, dirs_exist_ok=True
+                )
 
             else:
-                log.debug("Neither a dir, nor a file, that should be copied; file=%s", path)
+                log.debug(
+                    "Neither a dir, nor a file, that should be copied; file=%s", path
+                )
 
             log.info("Copied ignored file; file=%s", cp_res)
 

--- a/src/cmds/add/result_add.py
+++ b/src/cmds/add/result_add.py
@@ -1,8 +1,13 @@
 from ...errors.derived_branch_does_not_exist import DeriveBranchDoesNotExist
 from ...errors.no_fast_forward_merge import NoFastForwardMerge
 from ...errors.not_bare_repo_err import NotBareRepoErr
-from ...errors.worktree_creation_err import WorktreeCreationErr
 from ...errors.worktree_already_exists import WorktreeAlreadyExistsErr
+from ...errors.worktree_creation_err import WorktreeCreationErr
 
-
-AddWorktreeError = NotBareRepoErr | WorktreeCreationErr | WorktreeAlreadyExistsErr | DeriveBranchDoesNotExist | NoFastForwardMerge
+AddWorktreeError = (
+    NotBareRepoErr
+    | WorktreeCreationErr
+    | WorktreeAlreadyExistsErr
+    | DeriveBranchDoesNotExist
+    | NoFastForwardMerge
+)

--- a/src/cmds/clone/args_clone.py
+++ b/src/cmds/clone/args_clone.py
@@ -6,4 +6,3 @@ from pathlib import Path
 class CloneArgs:
     repository_link: str
     dest: Path
-

--- a/src/cmds/clone/cmd_clone.py
+++ b/src/cmds/clone/cmd_clone.py
@@ -1,23 +1,28 @@
 import logging
 import os
-import pygit2 as pg
-
 from pathlib import Path
+
+import pygit2 as pg
 from result import Err, Ok, Result
 
-from ...errors.path_cannot_be_file import PathCannotBeFile
 from ...errors.directory_not_empty import DirectoryNotEmpty
+from ...errors.path_cannot_be_file import PathCannotBeFile
 from ...errors.worktree_creation_err import WorktreeCreationErr
 from ...helpers.auth_agent_callback import AuthAgentCallback
-
 from .args_clone import CloneArgs
 from .result_clone import CloneRepositoryErr
 
 
-def clone_repository(clone_args: CloneArgs) -> Result[pg.Repository, CloneRepositoryErr]:
+def clone_repository(
+    clone_args: CloneArgs,
+) -> Result[pg.Repository, CloneRepositoryErr]:
     log = logging.getLogger(__name__)
 
-    log.debug("Attempting to create a repository; url=%s, dest=%s", clone_args.repository_link, clone_args.dest.absolute())
+    log.debug(
+        "Attempting to create a repository; url=%s, dest=%s",
+        clone_args.repository_link,
+        clone_args.dest.absolute(),
+    )
 
     if clone_args.dest.is_file(follow_symlinks=True):
         return Err(PathCannotBeFile())
@@ -35,14 +40,16 @@ def clone_repository(clone_args: CloneArgs) -> Result[pg.Repository, CloneReposi
             path=str(clone_args.dest.absolute()),
             bare=True,
             proxy=True,
-            callbacks=AuthAgentCallback()
+            callbacks=AuthAgentCallback(),
         )
 
     except pg.GitError as e:
         log.fatal("An error occurred; error=%s", e)
         return Err(DirectoryNotEmpty())
 
-    assert Path(repo.path).absolute() == clone_args.dest.absolute(), "A BARE repository must be created at the designated path"
+    assert Path(repo.path).absolute() == clone_args.dest.absolute(), (
+        "A BARE repository must be created at the designated path"
+    )
 
     default_branch = _get_default_branch(repo)
 
@@ -65,22 +72,32 @@ def _get_default_branch(repo: pg.Repository) -> str:
         return repo.head.shorthand
 
     except (pg.GitError, KeyError) as e:
-        log.warning("Could not determine default branch, falling back to 'main'; error=%s", e)
+        log.warning(
+            "Could not determine default branch, falling back to 'main'; error=%s", e
+        )
         return "main"
 
 
-def _create_default_worktree(repo: pg.Repository, dest: Path, branch_name: str) -> Result[None, WorktreeCreationErr]:
+def _create_default_worktree(
+    repo: pg.Repository, dest: Path, branch_name: str
+) -> Result[None, WorktreeCreationErr]:
     log = logging.getLogger(__name__)
 
     wt_path = dest / branch_name
 
-    log.debug("Attempting to create a default worktree; branch=%s, path=%s", branch_name, wt_path)
+    log.debug(
+        "Attempting to create a default worktree; branch=%s, path=%s",
+        branch_name,
+        wt_path,
+    )
 
     try:
         ref = repo.lookup_reference(f"refs/heads/{branch_name}")
         _new_wt = repo.add_worktree(branch_name, str(wt_path), ref)
     except (pg.GitError, OSError) as e:
-        log.error("Failed to create default worktree; branch=%s, error=%s", branch_name, e)
+        log.error(
+            "Failed to create default worktree; branch=%s, error=%s", branch_name, e
+        )
         return Err(WorktreeCreationErr())
 
     log.info("Created default worktree; branch=%s, path=%s", branch_name, wt_path)

--- a/src/cmds/clone/result_clone.py
+++ b/src/cmds/clone/result_clone.py
@@ -1,6 +1,5 @@
-from ...errors.path_cannot_be_file import PathCannotBeFile
 from ...errors.directory_not_empty import DirectoryNotEmpty
+from ...errors.path_cannot_be_file import PathCannotBeFile
 from ...errors.worktree_creation_err import WorktreeCreationErr
-
 
 CloneRepositoryErr = PathCannotBeFile | DirectoryNotEmpty | WorktreeCreationErr

--- a/src/cmds/config/cmd_config.py
+++ b/src/cmds/config/cmd_config.py
@@ -1,14 +1,17 @@
 import logging
 
-from result import Result, Ok, Err
-
+from result import Err, Ok, Result
 
 from .args_config import ConfigArgs
 from .result_config import ConfigError
-
 from ...errors.not_bare_repo_err import NotBareRepoErr
-
-from ...helpers.config_file import ensure_config_exists, read_config, write_config_file, set_list_value, get_list_value
+from ...helpers.config_file import (
+    ensure_config_exists,
+    get_list_value,
+    read_config,
+    set_list_value,
+    write_config_file,
+)
 from ...helpers.find_git import get_git_dir
 
 
@@ -39,10 +42,19 @@ def configure(config_args: ConfigArgs) -> Result[None, ConfigError]:
 
     if config_args.list:
         if config.has_section(repo_path):
-            log.info("add_commands = %s", get_list_value(config, repo_path, "add_commands"))
-            log.info("rm_commands = %s", get_list_value(config, repo_path, "rm_commands"))
-            log.info("exclude_files = %s", get_list_value(config, repo_path, "exclude_files"))
-            log.info("default_branch_name = %s", config.get(repo_path, "default_branch_name", fallback=""))
+            log.info(
+                "add_commands = %s", get_list_value(config, repo_path, "add_commands")
+            )
+            log.info(
+                "rm_commands = %s", get_list_value(config, repo_path, "rm_commands")
+            )
+            log.info(
+                "exclude_files = %s", get_list_value(config, repo_path, "exclude_files")
+            )
+            log.info(
+                "default_branch_name = %s",
+                config.get(repo_path, "default_branch_name", fallback=""),
+            )
         else:
             log.info("No configuration found for %s", repo_path)
 

--- a/src/cmds/config/result_config.py
+++ b/src/cmds/config/result_config.py
@@ -1,7 +1,6 @@
-from ...errors.not_bare_repo_err import NotBareRepoErr
+from ...errors.config_perm_err import ConfigPermErr
 from ...errors.config_read_err import ConfigReadErr
 from ...errors.config_write_err import ConfigWriteErr
-from ...errors.config_perm_err import ConfigPermErr
-
+from ...errors.not_bare_repo_err import NotBareRepoErr
 
 ConfigError = NotBareRepoErr | ConfigReadErr | ConfigWriteErr | ConfigPermErr

--- a/src/cmds/destroy/cmd_destroy.py
+++ b/src/cmds/destroy/cmd_destroy.py
@@ -1,17 +1,15 @@
 import logging
 import shutil
-import pygit2 as pg
-
 from pathlib import Path
-from result import Result, Ok, Err
+
+import pygit2 as pg
+from result import Err, Ok, Result
 
 from .args_destroy import DestroyArgs
 from .result_destroy import DestroyRepoError
-
 from ...errors.destroy_err import DestroyErr
 from ...errors.directory_not_found_err import DirectoryNotFoundErr
 from ...errors.not_bare_repo_err import NotBareRepoErr
-
 from ...helpers.config_file import remove_repo_entry
 
 
@@ -20,14 +18,20 @@ def destroy_repo(destroy_args: DestroyArgs) -> Result[None, DestroyRepoError]:
 
     directory: Path = Path(destroy_args.directory).absolute()
 
-    log.debug("Attempting to destroy bare repo; directory=%s, force=%s", directory, destroy_args.force)
+    log.debug(
+        "Attempting to destroy bare repo; directory=%s, force=%s",
+        directory,
+        destroy_args.force,
+    )
 
     if not directory.exists():
         log.warning("Directory does not exist; directory=%s", directory)
         return Err(DirectoryNotFoundErr())
 
     try:
-        bare_repo: pg.Repository = pg.Repository(str(directory), flags=pg.enums.RepositoryOpenFlag.BARE)
+        bare_repo: pg.Repository = pg.Repository(
+            str(directory), flags=pg.enums.RepositoryOpenFlag.BARE
+        )
     except pg.GitError:
         log.warning("Not a valid bare git repository; directory=%s", directory)
         return Err(NotBareRepoErr())

--- a/src/cmds/destroy/result_destroy.py
+++ b/src/cmds/destroy/result_destroy.py
@@ -1,9 +1,15 @@
-from ...errors.config_read_err import ConfigReadErr
 from ...errors.config_perm_err import ConfigPermErr
+from ...errors.config_read_err import ConfigReadErr
 from ...errors.config_write_err import ConfigWriteErr
 from ...errors.destroy_err import DestroyErr
 from ...errors.directory_not_found_err import DirectoryNotFoundErr
 from ...errors.not_bare_repo_err import NotBareRepoErr
 
-
-DestroyRepoError = NotBareRepoErr | DirectoryNotFoundErr | DestroyErr | ConfigReadErr | ConfigWriteErr | ConfigPermErr
+DestroyRepoError = (
+    NotBareRepoErr
+    | DirectoryNotFoundErr
+    | DestroyErr
+    | ConfigReadErr
+    | ConfigWriteErr
+    | ConfigPermErr
+)

--- a/src/cmds/rm/cmd_rm.py
+++ b/src/cmds/rm/cmd_rm.py
@@ -1,19 +1,16 @@
 import logging
 import shutil
-import pygit2 as pg
-
 from pathlib import Path
-from result import Result, Ok, Err
 
+import pygit2 as pg
+from result import Err, Ok, Result
 
 from .args_rm import RmArgs
 from .result_rm import RemoveWorktreeError
-
 from ...errors.not_bare_repo_err import NotBareRepoErr
 from ...errors.unmerged_changes_err import UnmergedChangesErr
 from ...errors.worktree_not_found_err import WorktreeNotFoundErr
 from ...errors.worktree_remove_err import WorktreeRemoveErr
-
 from ...helpers.config_file import ensure_config_exists, read_config, remove_repo_entry
 from ...helpers.find_git import get_git_dir
 
@@ -21,14 +18,23 @@ from ...helpers.find_git import get_git_dir
 def remove_worktree(rm_args: RmArgs) -> Result[None, RemoveWorktreeError]:
     log = logging.getLogger(__name__)
 
-    log.debug("Attempting to remove worktrees; branch_names=%s, force=%s", rm_args.branch_names, rm_args.force)
+    log.debug(
+        "Attempting to remove worktrees; branch_names=%s, force=%s",
+        rm_args.branch_names,
+        rm_args.force,
+    )
 
     git_dir = get_git_dir(rm_args.current_working_dir)
     if git_dir is None:
-        log.warning("No bare git repository found; working_directory=%s", rm_args.current_working_dir)
+        log.warning(
+            "No bare git repository found; working_directory=%s",
+            rm_args.current_working_dir,
+        )
         return Err(NotBareRepoErr())
 
-    bare_repo: pg.Repository = pg.Repository(git_dir, flags=pg.enums.RepositoryOpenFlag.BARE)
+    bare_repo: pg.Repository = pg.Repository(
+        git_dir, flags=pg.enums.RepositoryOpenFlag.BARE
+    )
     cwd: Path = Path(rm_args.current_working_dir).absolute()
 
     for branch_name in rm_args.branch_names:
@@ -37,7 +43,9 @@ def remove_worktree(rm_args: RmArgs) -> Result[None, RemoveWorktreeError]:
             case Err(_) as err:
                 return err
             case Ok(_):
-                log.info("Successfully removed worktree; worktree_branch=%s", branch_name)
+                log.info(
+                    "Successfully removed worktree; worktree_branch=%s", branch_name
+                )
                 pass
 
     remaining = bare_repo.list_worktrees()
@@ -71,14 +79,16 @@ def _remove_single(
 
     try:
         worktree: pg.Worktree = bare_repo.lookup_worktree(branch_name)
-    except (KeyError, pg.GitError ):
+    except (KeyError, pg.GitError):
         log.warning("Worktree not found; branch_name=%s", branch_name)
         return Err(WorktreeNotFoundErr())
 
     wt_path: Path = Path(worktree.path).absolute()
 
     if str(cwd).startswith(str(wt_path)):
-        log.error("Cannot remove the worktree you are currently in; worktree_path=%s", wt_path)
+        log.error(
+            "Cannot remove the worktree you are currently in; worktree_path=%s", wt_path
+        )
         return Err(WorktreeRemoveErr())
 
     if not force:
@@ -86,7 +96,7 @@ def _remove_single(
         if unmerged:
             log.error(
                 "Branch has commits not in default branch, refusing removal; branch=%s. Use --force to override.",
-                branch_name
+                branch_name,
             )
             return Err(UnmergedChangesErr())
 
@@ -123,13 +133,23 @@ def _has_unmerged_commits(repo: pg.Repository, git_dir: str, branch_name: str) -
                     default_branch = "main"
 
                 case Ok(config):
-                    default_branch = config.get(git_dir, "default_branch_name", fallback="main")
+                    default_branch = config.get(
+                        git_dir, "default_branch_name", fallback="main"
+                    )
 
-    log.debug("Checking unmerged commits; branch=%s, default_branch=%s", branch_name, default_branch)
+    log.debug(
+        "Checking unmerged commits; branch=%s, default_branch=%s",
+        branch_name,
+        default_branch,
+    )
 
     try:
-        branch_commit: pg.Commit = repo.lookup_reference(f"refs/heads/{branch_name}").peel(pg.Commit)
-        default_commit: pg.Commit = repo.lookup_reference(f"refs/heads/{default_branch}").peel(pg.Commit)
+        branch_commit: pg.Commit = repo.lookup_reference(
+            f"refs/heads/{branch_name}"
+        ).peel(pg.Commit)
+        default_commit: pg.Commit = repo.lookup_reference(
+            f"refs/heads/{default_branch}"
+        ).peel(pg.Commit)
 
         merge_base: pg.Oid = repo.merge_base(branch_commit.id, default_commit.id)
 

--- a/src/cmds/rm/result_rm.py
+++ b/src/cmds/rm/result_rm.py
@@ -1,10 +1,17 @@
-from ...errors.config_read_err import ConfigReadErr
 from ...errors.config_perm_err import ConfigPermErr
+from ...errors.config_read_err import ConfigReadErr
 from ...errors.config_write_err import ConfigWriteErr
 from ...errors.not_bare_repo_err import NotBareRepoErr
+from ...errors.unmerged_changes_err import UnmergedChangesErr
 from ...errors.worktree_not_found_err import WorktreeNotFoundErr
 from ...errors.worktree_remove_err import WorktreeRemoveErr
-from ...errors.unmerged_changes_err import UnmergedChangesErr
 
-
-RemoveWorktreeError = NotBareRepoErr | WorktreeNotFoundErr | WorktreeRemoveErr | ConfigReadErr | ConfigWriteErr | ConfigPermErr | UnmergedChangesErr
+RemoveWorktreeError = (
+    NotBareRepoErr
+    | WorktreeNotFoundErr
+    | WorktreeRemoveErr
+    | ConfigReadErr
+    | ConfigWriteErr
+    | ConfigPermErr
+    | UnmergedChangesErr
+)

--- a/src/errors/__init__.py
+++ b/src/errors/__init__.py
@@ -1,4 +1,4 @@
-from .not_bare_repo_err import NotBareRepoErr
-from .not_repo_err import NotRepoErr
-from .success import Success
-from .worktree_creation_err import WorktreeCreationErr
+from .not_bare_repo_err import NotBareRepoErr as NotBareRepoErr
+from .not_repo_err import NotRepoErr as NotRepoErr
+from .success import Success as Success
+from .worktree_creation_err import WorktreeCreationErr as WorktreeCreationErr

--- a/src/errors/no_fast_forward_merge.py
+++ b/src/errors/no_fast_forward_merge.py
@@ -1,3 +1,2 @@
 class NoFastForwardMerge:
     pass
-

--- a/src/exit_codes.py
+++ b/src/exit_codes.py
@@ -3,22 +3,22 @@ from enum import IntEnum
 
 class ExitCode(IntEnum):
     # Standard
-    SUCCESS          = 0
-    ERR_GENERAL      = 1
-    ERR_MISUSE       = 2    # Misuse of shell built-ins / bad arguments
-    ERR_NO_EXEC      = 126  # Command found but not executable
-    ERR_NOT_FOUND    = 127  # Command not found
+    SUCCESS = 0
+    ERR_GENERAL = 1
+    ERR_MISUSE = 2  # Misuse of shell built-ins / bad arguments
+    ERR_NO_EXEC = 126  # Command found but not executable
+    ERR_NOT_FOUND = 127  # Command not found
 
     # App-specific (166–254 range reserved for custom use)
-    ERR_PATH_IS_FILE    = 166  # Destination path is a file, expected directory
-    ERR_DIR_NOT_EMPTY   = 167  # Destination directory is not empty
-    ERR_NOT_BARE_REPO   = 168  # No bare git repository found
-    ERR_WORKTREE        = 169  # Worktree creation failed
-    ERR_BRANCH_MISSING  = 170  # Derived branch does not exist
-    ERR_NO_FF_MERGE     = 171  # Branch requires true merge, cannot fast-forward
-    ERR_CONFIG_READ     = 172  # Failed to read config file
-    ERR_CONFIG_WRITE    = 173  # Failed to write config file
-    ERR_CONFIG_PERM     = 174  # Insufficient permissions on config file
-    ERR_UNMERGED        = 175  # Branch has commits not present in default branch
-    ERR_WORKTREE_MISSING = 176 # Worktree or branch not found
-    ERR_DIR_NOT_FOUND    = 177 # Directory does not exist
+    ERR_PATH_IS_FILE = 166  # Destination path is a file, expected directory
+    ERR_DIR_NOT_EMPTY = 167  # Destination directory is not empty
+    ERR_NOT_BARE_REPO = 168  # No bare git repository found
+    ERR_WORKTREE = 169  # Worktree creation failed
+    ERR_BRANCH_MISSING = 170  # Derived branch does not exist
+    ERR_NO_FF_MERGE = 171  # Branch requires true merge, cannot fast-forward
+    ERR_CONFIG_READ = 172  # Failed to read config file
+    ERR_CONFIG_WRITE = 173  # Failed to write config file
+    ERR_CONFIG_PERM = 174  # Insufficient permissions on config file
+    ERR_UNMERGED = 175  # Branch has commits not present in default branch
+    ERR_WORKTREE_MISSING = 176  # Worktree or branch not found
+    ERR_DIR_NOT_FOUND = 177  # Directory does not exist

--- a/src/helpers/auth_agent_callback.py
+++ b/src/helpers/auth_agent_callback.py
@@ -1,12 +1,13 @@
 import logging
 from typing import final, override
+
 from pygit2 import CredentialType, KeypairFromAgent, RemoteCallbacks
 from pygit2.remotes import TransferProgress
 from rich.progress import Progress
 
 from ..errors.git_auth_error import GitAuthError
-
 from .logger import console
+
 
 @final
 class AuthAgentCallback(RemoteCallbacks):
@@ -23,7 +24,9 @@ class AuthAgentCallback(RemoteCallbacks):
         _ = self._progress.__enter__()
 
     @override
-    def credentials(self, url: str, username_from_url: str | None, allowed_types: CredentialType):
+    def credentials(
+        self, url: str, username_from_url: str | None, allowed_types: CredentialType
+    ):
         if allowed_types & CredentialType.SSH_KEY:
             return KeypairFromAgent(username_from_url or "git")
 
@@ -37,7 +40,11 @@ class AuthAgentCallback(RemoteCallbacks):
             return
 
         if stats.total_objects == stats.indexed_objects:
-            log.debug("Downloading finished; total_objects=%s, processed_objects=%s", stats.total_objects, stats.indexed_objects)
+            log.debug(
+                "Downloading finished; total_objects=%s, processed_objects=%s",
+                stats.total_objects,
+                stats.indexed_objects,
+            )
 
             self._progress.__exit__(None, None, None)
             return
@@ -46,12 +53,9 @@ class AuthAgentCallback(RemoteCallbacks):
             self._task = self._progress.add_task(
                 description="",
                 total=stats.total_objects,
-                completed=stats.indexed_objects
+                completed=stats.indexed_objects,
             )
 
         self._progress.update(
-            self._task,
-            description=None,
-            completed=stats.indexed_objects,
-            refresh=True
+            self._task, description=None, completed=stats.indexed_objects, refresh=True
         )

--- a/src/helpers/config_file.py
+++ b/src/helpers/config_file.py
@@ -1,14 +1,13 @@
 import configparser
 import logging
 import os
-
 from pathlib import Path
+
 from result import Err, Ok, Result
 
+from ..errors.config_perm_err import ConfigPermErr
 from ..errors.config_read_err import ConfigReadErr
 from ..errors.config_write_err import ConfigWriteErr
-from ..errors.config_perm_err import ConfigPermErr
-
 
 CONFIG_PATH = Path.home() / ".gitconfig_wt"
 
@@ -58,24 +57,33 @@ def read_config(path: Path) -> Result[configparser.RawConfigParser, ConfigReadEr
         return Err(ConfigReadErr())
 
 
-def set_list_value(config: configparser.RawConfigParser, section: str, key: str, values: tuple[str, ...]) -> None:
+def set_list_value(
+    config: configparser.RawConfigParser,
+    section: str,
+    key: str,
+    values: tuple[str, ...],
+) -> None:
     if not values:
         return
 
     config.set(section, key, "\n" + "\n".join(values))
 
 
-def get_list_value(config: configparser.RawConfigParser, section: str, key: str) -> list[str]:
+def get_list_value(
+    config: configparser.RawConfigParser, section: str, key: str
+) -> list[str]:
     raw = config.get(section, key, fallback="")
 
     return [line.strip() for line in raw.splitlines() if line.strip()]
 
 
-def write_config_file(config: configparser.RawConfigParser, path: Path) -> Result[None, ConfigWriteErr]:
+def write_config_file(
+    config: configparser.RawConfigParser, path: Path
+) -> Result[None, ConfigWriteErr]:
     log = logging.getLogger(__name__)
 
     try:
-        with open(path, 'w') as f:
+        with open(path, "w") as f:
             for section in config.sections():
                 _ = f.write(f"[{section}]\n")
 
@@ -100,7 +108,9 @@ def write_config_file(config: configparser.RawConfigParser, path: Path) -> Resul
         return Err(ConfigWriteErr())
 
 
-def remove_repo_entry(repo_path: str) -> Result[None, ConfigReadErr | ConfigWriteErr | ConfigPermErr]:
+def remove_repo_entry(
+    repo_path: str,
+) -> Result[None, ConfigReadErr | ConfigWriteErr | ConfigPermErr]:
     log = logging.getLogger(__name__)
 
     ensure_res = ensure_config_exists()
@@ -129,7 +139,9 @@ def remove_repo_entry(repo_path: str) -> Result[None, ConfigReadErr | ConfigWrit
     return Ok(None)
 
 
-def ensure_repo_entry(repo_path: Path) -> Result[None, ConfigReadErr | ConfigWriteErr | ConfigPermErr]:
+def ensure_repo_entry(
+    repo_path: Path,
+) -> Result[None, ConfigReadErr | ConfigWriteErr | ConfigPermErr]:
     """Ensure a section exists in the config for repo_path. Called after clone."""
     ensure_res = ensure_config_exists()
     match ensure_res:
@@ -146,8 +158,8 @@ def ensure_repo_entry(repo_path: Path) -> Result[None, ConfigReadErr | ConfigWri
         case Ok(config):
             pass
 
-    if not config.has_section(str( repo_path.absolute() )):
-        config.add_section(str( repo_path.absolute() ))
+    if not config.has_section(str(repo_path.absolute())):
+        config.add_section(str(repo_path.absolute()))
         return write_config_file(config, config_path)
 
     return Ok(None)

--- a/src/helpers/find_git.py
+++ b/src/helpers/find_git.py
@@ -7,7 +7,7 @@ def get_git_dir(start: str) -> str | None:
 
     # If git is a file, then we're in a branch of the worktree
     if git.is_file():
-        return str( path.parent )
+        return str(path.parent)
 
     # If git is a dir, then we're not in a bare repo
     if git.is_dir():
@@ -15,11 +15,11 @@ def get_git_dir(start: str) -> str | None:
 
     # If at least 3 are present, then we're in the bare repo's root
     bare_root_dic = {
-        'config': False,
-        'HEAD': False,
-        'packed-refs': False,
-        'objects': False,
-        'FETCH_HEAD': False
+        "config": False,
+        "HEAD": False,
+        "packed-refs": False,
+        "objects": False,
+        "FETCH_HEAD": False,
     }
 
     for dir in path.iterdir():
@@ -28,7 +28,6 @@ def get_git_dir(start: str) -> str | None:
 
     contains_git_files: bool = sum(bare_root_dic.values()) >= 3
     if contains_git_files:
-        return str( path.absolute() )
+        return str(path.absolute())
     else:
         return None
-

--- a/src/helpers/logger.py
+++ b/src/helpers/logger.py
@@ -1,12 +1,12 @@
 import os
-
 from logging import basicConfig
+
 import click
 from rich.console import Console
 from rich.logging import RichHandler
 
+console = Console(stderr=True)  # Shared
 
-console = Console(stderr=True) # Shared
 
 def setup_logging() -> None:
     level = os.getenv("LOG_LEVEL", "INFO").upper()
@@ -26,6 +26,6 @@ def setup_logging() -> None:
                 omit_repeated_times=False,
                 tracebacks_show_locals=True,
                 tracebacks_suppress=[click],
-            )
-        ]
+            ),
+        ],
     )

--- a/src/main.py
+++ b/src/main.py
@@ -1,43 +1,37 @@
-import os
-import click
 import logging
-
+import os
 from pathlib import Path
+
+import click
 from result import Err, Ok
 
-from .errors.path_cannot_be_file import PathCannotBeFile
-from .errors.directory_not_empty import DirectoryNotEmpty
-from .errors.derived_branch_does_not_exist import DeriveBranchDoesNotExist
-from .errors.no_fast_forward_merge import NoFastForwardMerge
-from .errors.not_bare_repo_err import NotBareRepoErr
-from .errors.worktree_creation_err import WorktreeCreationErr
+from .cmds.add.args_add import AddArgs
+from .cmds.add.cmd_add import add_worktree
+from .cmds.clone.args_clone import CloneArgs
+from .cmds.clone.cmd_clone import clone_repository
+from .cmds.config.args_config import ConfigArgs
+from .cmds.config.cmd_config import configure
+from .cmds.destroy.args_destroy import DestroyArgs
+from .cmds.destroy.cmd_destroy import destroy_repo
+from .cmds.rm.args_rm import RmArgs
+from .cmds.rm.cmd_rm import remove_worktree
+from .errors.config_perm_err import ConfigPermErr
 from .errors.config_read_err import ConfigReadErr
 from .errors.config_write_err import ConfigWriteErr
-from .errors.config_perm_err import ConfigPermErr
+from .errors.derived_branch_does_not_exist import DeriveBranchDoesNotExist
+from .errors.destroy_err import DestroyErr
+from .errors.directory_not_empty import DirectoryNotEmpty
+from .errors.directory_not_found_err import DirectoryNotFoundErr
+from .errors.no_fast_forward_merge import NoFastForwardMerge
+from .errors.not_bare_repo_err import NotBareRepoErr
+from .errors.path_cannot_be_file import PathCannotBeFile
 from .errors.unmerged_changes_err import UnmergedChangesErr
+from .errors.worktree_creation_err import WorktreeCreationErr
 from .errors.worktree_not_found_err import WorktreeNotFoundErr
 from .errors.worktree_remove_err import WorktreeRemoveErr
-from .errors.directory_not_found_err import DirectoryNotFoundErr
-from .errors.destroy_err import DestroyErr
-
 from .exit_codes import ExitCode
-from .helpers.logger import setup_logging
 from .helpers.config_file import ensure_repo_entry
-
-from .cmds.add.cmd_add import add_worktree
-from .cmds.add.args_add import AddArgs
-
-from .cmds.clone.cmd_clone import clone_repository
-from .cmds.clone.args_clone import CloneArgs
-
-from .cmds.config.cmd_config import configure
-from .cmds.config.args_config import ConfigArgs
-
-from .cmds.rm.cmd_rm import remove_worktree
-from .cmds.rm.args_rm import RmArgs
-
-from .cmds.destroy.cmd_destroy import destroy_repo
-from .cmds.destroy.args_destroy import DestroyArgs
+from .helpers.logger import setup_logging
 
 
 @click.group()
@@ -50,15 +44,32 @@ def cli():
 @cli.command()
 @click.argument("NEW_BRANCH_NAME", type=str)
 @click.argument("DERIVE_FROM_BRANCH", type=str, required=False)
-@click.option("--force", "-f", is_flag=True, default=False, help="Force checkout, even if branch already exists locally")
-@click.option("--exclude", "-e", type=str, default=[], help="""
+@click.option(
+    "--force",
+    "-f",
+    is_flag=True,
+    default=False,
+    help="Force checkout, even if branch already exists locally",
+)
+@click.option(
+    "--exclude",
+    "-e",
+    type=str,
+    default=[],
+    help="""
 Exclude files from being copied over. Provide a comma-seperated list
 
 Example: `--exclude="node_modules,dist,target,bin"`
 
 WARNING: This can override the config file
-""")
-def add(new_branch_name: str, derive_from_branch: str, exclude: list[str]=[], force: bool=False):
+""",
+)
+def add(
+    new_branch_name: str,
+    derive_from_branch: str,
+    exclude: list[str] | None = None,
+    force: bool = False,
+):
     """
     Create a worktree
 
@@ -71,12 +82,12 @@ def add(new_branch_name: str, derive_from_branch: str, exclude: list[str]=[], fo
     should_nest_dirs: bool = False
     exclude_files_from_copy: list[str] = exclude or []
 
-    add_args: AddArgs = AddArgs(
+    add_args = AddArgs(
         new_branch_name,
         derive_from_branch,
         should_nest_dirs,
         exclude_files_from_copy,
-        force
+        force,
     )
 
     worktree_creaton_res = add_worktree(add_args)
@@ -86,19 +97,27 @@ def add(new_branch_name: str, derive_from_branch: str, exclude: list[str]=[], fo
 
     match worktree_creaton_res:
         case Err(NotBareRepoErr()):
-            log.error("Cannot find a BARE git repository in the current working directory.")
+            log.error(
+                "Cannot find a BARE git repository in the current working directory."
+            )
             exit(ExitCode.ERR_NOT_BARE_REPO)
 
         case Err(WorktreeCreationErr()):
-            log.error("An error occurred while trying to create the new branch. Please, try again.")
+            log.error(
+                "An error occurred while trying to create the new branch. Please, try again."
+            )
             exit(ExitCode.ERR_WORKTREE)
 
         case Err(DeriveBranchDoesNotExist()):
-            log.error("The derived branch does not exist. A worktree from it cannot be created.")
+            log.error(
+                "The derived branch does not exist. A worktree from it cannot be created."
+            )
             exit(ExitCode.ERR_BRANCH_MISSING)
 
         case Err(NoFastForwardMerge()):
-            log.error("The derived branch has conflicts and cannot fast-forward changes from origin.")
+            log.error(
+                "The derived branch has conflicts and cannot fast-forward changes from origin."
+            )
             exit(ExitCode.ERR_NO_FF_MERGE)
 
         case Err(_):
@@ -116,27 +135,33 @@ def add(new_branch_name: str, derive_from_branch: str, exclude: list[str]=[], fo
     type=str,
     multiple=True,
     metavar="<CMD>",
-    help="Command to run after successful worktree creation. Can be repeated for multiple commands. Automatically ran after `git wt add`.")
+    help="Command to run after successful worktree creation. Can be repeated for multiple commands. Automatically ran after `git wt add`.",
+)
 @click.option(
     "--remove-command",
     type=str,
     multiple=True,
     metavar="<CMD>",
-    help="Command to run after successful worktree removal. Can be repeated for multiple commands. Automatically ran after `git wt rm`.")
+    help="Command to run after successful worktree removal. Can be repeated for multiple commands. Automatically ran after `git wt rm`.",
+)
 @click.option(
-    "--exclude", "-e",
+    "--exclude",
+    "-e",
     type=str,
     multiple=True,
     metavar="<GLOB>",
-    help="Glob pattern of files to exclude when copying after worktree creation. Can be repeated to specify multiple patterns.")
+    help="Glob pattern of files to exclude when copying after worktree creation. Can be repeated to specify multiple patterns.",
+)
 @click.option(
     "--default-branch",
     type=str,
     default="",
     metavar="<BRANCH>",
-    help="Default branch name to derive new worktrees from.")
+    help="Default branch name to derive new worktrees from.",
+)
 @click.option(
-    "--list", "-l",
+    "--list",
+    "-l",
     is_flag=True,
     default=False,
     help="""
@@ -147,17 +172,24 @@ def add(new_branch_name: str, derive_from_branch: str, exclude: list[str]=[], fo
         Example: ["node_modules", "cache"]
 
         The `git wt add` wouldn't need `--exclude "node_modules" --exclude "cache"` every time it's ran in the configured repo.
-    """)
-def config(add_command: tuple[str, ...], remove_command: tuple[str, ...], exclude: tuple[str, ...], default_branch: str, list: bool):
+    """,
+)
+def config(
+    add_command: tuple[str, ...],
+    remove_command: tuple[str, ...],
+    exclude: tuple[str, ...],
+    default_branch: str,
+    list: bool,
+):
     log = logging.getLogger(__name__)
 
-    config_args: ConfigArgs = ConfigArgs(
+    config_args = ConfigArgs(
         current_working_dir=os.getcwd(),
         add_commands=add_command,
         remove_commands=remove_command,
         copy_exclude=exclude,
         default_branch_name=default_branch,
-        list=list
+        list=list,
     )
 
     config_res = configure(config_args)
@@ -166,7 +198,9 @@ def config(add_command: tuple[str, ...], remove_command: tuple[str, ...], exclud
 
     match config_res:
         case Err(NotBareRepoErr()):
-            log.error("Cannot find a BARE git repository in the current working directory.")
+            log.error(
+                "Cannot find a BARE git repository in the current working directory."
+            )
             exit(ExitCode.ERR_NOT_BARE_REPO)
 
         case Err(ConfigReadErr()):
@@ -229,10 +263,7 @@ def clone(repository: str, directory: str):
         case Ok(_):
             pass
 
-    clone_args: CloneArgs = CloneArgs(
-        repository_link=repository,
-        dest=dest
-    )
+    clone_args = CloneArgs(repository_link=repository, dest=dest)
 
     clone_res = clone_repository(clone_args)
 
@@ -256,22 +287,30 @@ def clone(repository: str, directory: str):
             exit(ExitCode.ERR_GENERAL)
 
         case Ok(repo):
-            log.info("Repository cloned successfully; repo_workdir=%s, repo_path=%s", repo.workdir, repo.path)
+            log.info(
+                "Repository cloned successfully; repo_workdir=%s, repo_path=%s",
+                repo.workdir,
+                repo.path,
+            )
             exit(ExitCode.SUCCESS)
 
 
 @cli.command()
 @click.argument("BRANCH_NAMES", nargs=-1, required=True, type=str)
-@click.option("--force", "-f", is_flag=True, default=False, help="Remove even if the branch has commits not present in the default branch.")
+@click.option(
+    "--force",
+    "-f",
+    is_flag=True,
+    default=False,
+    help="Remove even if the branch has commits not present in the default branch.",
+)
 def rm(branch_names: tuple[str, ...], force: bool):
     """Remove one or more worktrees."""
 
     log = logging.getLogger(__name__)
 
-    rm_args: RmArgs = RmArgs(
-        branch_names=branch_names,
-        current_working_dir=os.getcwd(),
-        force=force
+    rm_args = RmArgs(
+        branch_names=branch_names, current_working_dir=os.getcwd(), force=force
     )
 
     rm_res = remove_worktree(rm_args)
@@ -280,7 +319,9 @@ def rm(branch_names: tuple[str, ...], force: bool):
 
     match rm_res:
         case Err(NotBareRepoErr()):
-            log.error("Cannot find a BARE git repository in the current working directory.")
+            log.error(
+                "Cannot find a BARE git repository in the current working directory."
+            )
             exit(ExitCode.ERR_NOT_BARE_REPO)
 
         case Err(WorktreeNotFoundErr()):
@@ -288,7 +329,9 @@ def rm(branch_names: tuple[str, ...], force: bool):
             exit(ExitCode.ERR_WORKTREE_MISSING)
 
         case Err(UnmergedChangesErr()):
-            log.error("Branch has commits not in the default branch. Use --force to override.")
+            log.error(
+                "Branch has commits not in the default branch. Use --force to override."
+            )
             exit(ExitCode.ERR_UNMERGED)
 
         case Err(WorktreeRemoveErr()):
@@ -306,7 +349,9 @@ def rm(branch_names: tuple[str, ...], force: bool):
 
 @cli.command()
 @click.argument("DIRECTORY", required=True, type=str)
-@click.option("--force", "-f", is_flag=True, default=False, help="Skip confirmation prompt.")
+@click.option(
+    "--force", "-f", is_flag=True, default=False, help="Skip confirmation prompt."
+)
 def destroy(directory: str, force: bool):
     """
     Destroy an entire bare-repo worktree directory.
@@ -331,12 +376,12 @@ def destroy(directory: str, force: bool):
     log = logging.getLogger(__name__)
 
     if not force:
-        _ = click.confirm(f"This will permanently delete '{directory}' and all its contents. Continue?", abort=True)
+        _ = click.confirm(
+            f"This will permanently delete '{directory}' and all its contents. Continue?",
+            abort=True,
+        )
 
-    destroy_args: DestroyArgs = DestroyArgs(
-        directory=directory,
-        force=force
-    )
+    destroy_args = DestroyArgs(directory=directory, force=force)
 
     destroy_res = destroy_repo(destroy_args)
 
@@ -394,4 +439,3 @@ def switch():
 
 if __name__ == "__main__":
     cli()
-


### PR DESCRIPTION
## Summary

Apply `ruff format` and `ruff check --fix` across all `src/` files. No logic changes.

Changes applied by ruff:
- Import sorting (isort) across all modules
- String quote normalisation (single → double)
- Remove extra blank lines and trailing newlines
- Collapse overlong log/call expressions to ruff-compliant multi-line form
- Explicit re-exports in `errors/__init__.py` (`F401` fix)
- Fix mutable default argument in `add` command signature (`B006`: `list[str]=[]  →  list[str] | None = None`)

## Merge order

This is **#2 of 5** split from #3. Merge after `chore/ruff-config` (PR #6) so the ruff config is in place before the CI checks this branch.

## Files changed

19 files in `src/`