### PR TITLE
ci: add GitHub Actions pipeline

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,61 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install ruff
+
+      - name: Check formatting
+        run: ruff format --check src/
+
+      - name: Lint
+        run: ruff check src/
+
+  build:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install package
+        run: pip install .
+
+      - name: Verify CLI entry point
+        run: git-wt --version
+
+  test:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install package with dev deps
+        run: pip install -e ".[dev]"
+
+      - name: Run tests
+        run: pytest --tb=short -q

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: pip install ruff
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install package
         run: pip install .
@@ -52,10 +52,10 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install package with dev deps
         run: pip install -e ".[dev]"
 
       - name: Run tests
-        run: pytest --tb=short -q
+        run: pytest --tb=short -q || [ $? -eq 5 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "A git-worktree extension to make using worktrees a pain of the past"
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 dependencies = [
     "click>=8.1",
     "pygit2==1.19.2",
@@ -34,7 +34,7 @@ testpaths = ["tests"]
 pythonpath = ["."]
 
 [tool.ruff]
-target-version = "py311"
+target-version = "py312"
 line-length = 140
 
 [tool.ruff.lint]

--- a/src/cmds/add/cmd_add.py
+++ b/src/cmds/add/cmd_add.py
@@ -2,29 +2,25 @@ import logging
 import os
 from fnmatch import fnmatch
 from pathlib import Path
+from shutil import copy2, copytree
 
 import pygit2 as pg
 from result import Err, Ok, Result
-from shutil import copy2, copytree
 
-from .args_add import AddArgs
-from .result_add import AddWorktreeError
 from ...errors.derived_branch_does_not_exist import DeriveBranchDoesNotExist
 from ...errors.no_fast_forward_merge import NoFastForwardMerge
 from ...errors.not_bare_repo_err import NotBareRepoErr
 from ...errors.worktree_already_exists import WorktreeAlreadyExistsErr
 from ...errors.worktree_creation_err import WorktreeCreationErr
 from ...helpers.find_git import get_git_dir
+from .args_add import AddArgs
+from .result_add import AddWorktreeError
 
 
 def add_worktree(add_args: AddArgs) -> Result[None, AddWorktreeError]:
     log = logging.getLogger(__name__)
 
-    branch_name: str = (
-        add_args.new_branch_name
-        if add_args.should_nest_dirs
-        else add_args.new_branch_name.replace("/", "-")
-    )
+    branch_name: str = add_args.new_branch_name if add_args.should_nest_dirs else add_args.new_branch_name.replace("/", "-")
     current_path: str = os.getcwd()
 
     log.debug(
@@ -54,9 +50,7 @@ def add_worktree(add_args: AddArgs) -> Result[None, AddWorktreeError]:
 
     # TODO: Specify the repo to be based on the derived_branch
     log.info("Git repository found; git_dir=%s", git_dir)
-    bare_repo: pg.Repository = pg.Repository(
-        git_dir, flags=pg.enums.RepositoryOpenFlag.BARE
-    )
+    bare_repo: pg.Repository = pg.Repository(git_dir, flags=pg.enums.RepositoryOpenFlag.BARE)
 
     log.debug("Repository opened; repository=%s", bare_repo)
 
@@ -76,9 +70,7 @@ def add_worktree(add_args: AddArgs) -> Result[None, AddWorktreeError]:
     #
     # log.info("Fetched commits from origin; num_fetched_commits=%s", transfer_progress.total_deltas)
 
-    remote_branch = bare_repo.lookup_reference(
-        f"refs/heads/{add_args.derive_from_branch}"
-    ).peel(pg.Commit)
+    remote_branch = bare_repo.lookup_reference(f"refs/heads/{add_args.derive_from_branch}").peel(pg.Commit)
     analysis, _ = bare_repo.merge_analysis(remote_branch.id)
 
     log.debug(
@@ -97,9 +89,7 @@ def add_worktree(add_args: AddArgs) -> Result[None, AddWorktreeError]:
         # NOTE: Untested!
         # Move HEAD and working tree forward
         _ = bare_repo.checkout_tree(treeish=bare_repo.get(remote_branch.id))  # pyright: ignore[reportUnknownMemberType]
-        bare_repo.lookup_reference(
-            f"refs/heads/{add_args.derive_from_branch}"
-        ).set_target(remote_branch.id)
+        bare_repo.lookup_reference(f"refs/heads/{add_args.derive_from_branch}").set_target(remote_branch.id)
         bare_repo.head.set_target(remote_branch.id)
 
         log.info("Fast-forwarded ref branch; fast_forwarded=%s", remote_branch.id)
@@ -147,15 +137,9 @@ def add_worktree(add_args: AddArgs) -> Result[None, AddWorktreeError]:
 
         return Err(WorktreeAlreadyExistsErr())
 
-    assert new_worktree is not None, (
-        "The new worktree must be created. Something wasn not handled correctly"
-    )
-    assert new_worktree.name == branch_name, (
-        "Worktree name must equal to the branch name provided"
-    )
-    assert new_worktree.path == str(wt_path), (
-        "The path of the worktree must be the same as the given path for worktree creation"
-    )
+    assert new_worktree is not None, "The new worktree must be created. Something wasn not handled correctly"
+    assert new_worktree.name == branch_name, "Worktree name must equal to the branch name provided"
+    assert new_worktree.path == str(wt_path), "The path of the worktree must be the same as the given path for worktree creation"
 
     derive_branch_path: Path = Path(git_dir, add_args.derive_from_branch)
     log.info(
@@ -171,17 +155,11 @@ def add_worktree(add_args: AddArgs) -> Result[None, AddWorktreeError]:
         derived_repo.workdir,
     )
 
-    git_ignored_files = [
-        Path(derived_repo.workdir, ignored)
-        for ignored in derived_repo.status(untracked_files="no", ignored=True)
-    ]
+    git_ignored_files = [Path(derived_repo.workdir, ignored) for ignored in derived_repo.status(untracked_files="no", ignored=True)]
     git_ignored_filtered_files = [
         ignored_file
         for ignored_file in git_ignored_files
-        if not any(
-            fnmatch(ignored_file.name, excluded_glob)
-            for excluded_glob in add_args.exclude
-        )
+        if not any(fnmatch(ignored_file.name, excluded_glob) for excluded_glob in add_args.exclude)
     ]
 
     log.debug(
@@ -197,14 +175,10 @@ def add_worktree(add_args: AddArgs) -> Result[None, AddWorktreeError]:
                 cp_res = copy2(str(path), new_worktree.path, follow_symlinks=True)
 
             elif path.is_dir():
-                cp_res = copytree(
-                    str(path), new_worktree.path, symlinks=True, dirs_exist_ok=True
-                )
+                cp_res = copytree(str(path), new_worktree.path, symlinks=True, dirs_exist_ok=True)
 
             else:
-                log.debug(
-                    "Neither a dir, nor a file, that should be copied; file=%s", path
-                )
+                log.debug("Neither a dir, nor a file, that should be copied; file=%s", path)
 
             log.info("Copied ignored file; file=%s", cp_res)
 

--- a/src/cmds/add/result_add.py
+++ b/src/cmds/add/result_add.py
@@ -4,10 +4,4 @@ from ...errors.not_bare_repo_err import NotBareRepoErr
 from ...errors.worktree_already_exists import WorktreeAlreadyExistsErr
 from ...errors.worktree_creation_err import WorktreeCreationErr
 
-AddWorktreeError = (
-    NotBareRepoErr
-    | WorktreeCreationErr
-    | WorktreeAlreadyExistsErr
-    | DeriveBranchDoesNotExist
-    | NoFastForwardMerge
-)
+AddWorktreeError = NotBareRepoErr | WorktreeCreationErr | WorktreeAlreadyExistsErr | DeriveBranchDoesNotExist | NoFastForwardMerge

--- a/src/cmds/clone/cmd_clone.py
+++ b/src/cmds/clone/cmd_clone.py
@@ -47,9 +47,7 @@ def clone_repository(
         log.fatal("An error occurred; error=%s", e)
         return Err(DirectoryNotEmpty())
 
-    assert Path(repo.path).absolute() == clone_args.dest.absolute(), (
-        "A BARE repository must be created at the designated path"
-    )
+    assert Path(repo.path).absolute() == clone_args.dest.absolute(), "A BARE repository must be created at the designated path"
 
     default_branch = _get_default_branch(repo)
 
@@ -72,15 +70,11 @@ def _get_default_branch(repo: pg.Repository) -> str:
         return repo.head.shorthand
 
     except (pg.GitError, KeyError) as e:
-        log.warning(
-            "Could not determine default branch, falling back to 'main'; error=%s", e
-        )
+        log.warning("Could not determine default branch, falling back to 'main'; error=%s", e)
         return "main"
 
 
-def _create_default_worktree(
-    repo: pg.Repository, dest: Path, branch_name: str
-) -> Result[None, WorktreeCreationErr]:
+def _create_default_worktree(repo: pg.Repository, dest: Path, branch_name: str) -> Result[None, WorktreeCreationErr]:
     log = logging.getLogger(__name__)
 
     wt_path = dest / branch_name
@@ -95,9 +89,7 @@ def _create_default_worktree(
         ref = repo.lookup_reference(f"refs/heads/{branch_name}")
         _new_wt = repo.add_worktree(branch_name, str(wt_path), ref)
     except (pg.GitError, OSError) as e:
-        log.error(
-            "Failed to create default worktree; branch=%s, error=%s", branch_name, e
-        )
+        log.error("Failed to create default worktree; branch=%s, error=%s", branch_name, e)
         return Err(WorktreeCreationErr())
 
     log.info("Created default worktree; branch=%s, path=%s", branch_name, wt_path)

--- a/src/cmds/config/cmd_config.py
+++ b/src/cmds/config/cmd_config.py
@@ -2,8 +2,6 @@ import logging
 
 from result import Err, Ok, Result
 
-from .args_config import ConfigArgs
-from .result_config import ConfigError
 from ...errors.not_bare_repo_err import NotBareRepoErr
 from ...helpers.config_file import (
     ensure_config_exists,
@@ -13,6 +11,8 @@ from ...helpers.config_file import (
     write_config_file,
 )
 from ...helpers.find_git import get_git_dir
+from .args_config import ConfigArgs
+from .result_config import ConfigError
 
 
 def configure(config_args: ConfigArgs) -> Result[None, ConfigError]:
@@ -42,15 +42,9 @@ def configure(config_args: ConfigArgs) -> Result[None, ConfigError]:
 
     if config_args.list:
         if config.has_section(repo_path):
-            log.info(
-                "add_commands = %s", get_list_value(config, repo_path, "add_commands")
-            )
-            log.info(
-                "rm_commands = %s", get_list_value(config, repo_path, "rm_commands")
-            )
-            log.info(
-                "exclude_files = %s", get_list_value(config, repo_path, "exclude_files")
-            )
+            log.info("add_commands = %s", get_list_value(config, repo_path, "add_commands"))
+            log.info("rm_commands = %s", get_list_value(config, repo_path, "rm_commands"))
+            log.info("exclude_files = %s", get_list_value(config, repo_path, "exclude_files"))
             log.info(
                 "default_branch_name = %s",
                 config.get(repo_path, "default_branch_name", fallback=""),

--- a/src/cmds/destroy/cmd_destroy.py
+++ b/src/cmds/destroy/cmd_destroy.py
@@ -5,12 +5,12 @@ from pathlib import Path
 import pygit2 as pg
 from result import Err, Ok, Result
 
-from .args_destroy import DestroyArgs
-from .result_destroy import DestroyRepoError
 from ...errors.destroy_err import DestroyErr
 from ...errors.directory_not_found_err import DirectoryNotFoundErr
 from ...errors.not_bare_repo_err import NotBareRepoErr
 from ...helpers.config_file import remove_repo_entry
+from .args_destroy import DestroyArgs
+from .result_destroy import DestroyRepoError
 
 
 def destroy_repo(destroy_args: DestroyArgs) -> Result[None, DestroyRepoError]:
@@ -29,9 +29,7 @@ def destroy_repo(destroy_args: DestroyArgs) -> Result[None, DestroyRepoError]:
         return Err(DirectoryNotFoundErr())
 
     try:
-        bare_repo: pg.Repository = pg.Repository(
-            str(directory), flags=pg.enums.RepositoryOpenFlag.BARE
-        )
+        bare_repo: pg.Repository = pg.Repository(str(directory), flags=pg.enums.RepositoryOpenFlag.BARE)
     except pg.GitError:
         log.warning("Not a valid bare git repository; directory=%s", directory)
         return Err(NotBareRepoErr())

--- a/src/cmds/destroy/result_destroy.py
+++ b/src/cmds/destroy/result_destroy.py
@@ -5,11 +5,4 @@ from ...errors.destroy_err import DestroyErr
 from ...errors.directory_not_found_err import DirectoryNotFoundErr
 from ...errors.not_bare_repo_err import NotBareRepoErr
 
-DestroyRepoError = (
-    NotBareRepoErr
-    | DirectoryNotFoundErr
-    | DestroyErr
-    | ConfigReadErr
-    | ConfigWriteErr
-    | ConfigPermErr
-)
+DestroyRepoError = NotBareRepoErr | DirectoryNotFoundErr | DestroyErr | ConfigReadErr | ConfigWriteErr | ConfigPermErr

--- a/src/cmds/rm/cmd_rm.py
+++ b/src/cmds/rm/cmd_rm.py
@@ -5,14 +5,14 @@ from pathlib import Path
 import pygit2 as pg
 from result import Err, Ok, Result
 
-from .args_rm import RmArgs
-from .result_rm import RemoveWorktreeError
 from ...errors.not_bare_repo_err import NotBareRepoErr
 from ...errors.unmerged_changes_err import UnmergedChangesErr
 from ...errors.worktree_not_found_err import WorktreeNotFoundErr
 from ...errors.worktree_remove_err import WorktreeRemoveErr
 from ...helpers.config_file import ensure_config_exists, read_config, remove_repo_entry
 from ...helpers.find_git import get_git_dir
+from .args_rm import RmArgs
+from .result_rm import RemoveWorktreeError
 
 
 def remove_worktree(rm_args: RmArgs) -> Result[None, RemoveWorktreeError]:
@@ -32,9 +32,7 @@ def remove_worktree(rm_args: RmArgs) -> Result[None, RemoveWorktreeError]:
         )
         return Err(NotBareRepoErr())
 
-    bare_repo: pg.Repository = pg.Repository(
-        git_dir, flags=pg.enums.RepositoryOpenFlag.BARE
-    )
+    bare_repo: pg.Repository = pg.Repository(git_dir, flags=pg.enums.RepositoryOpenFlag.BARE)
     cwd: Path = Path(rm_args.current_working_dir).absolute()
 
     for branch_name in rm_args.branch_names:
@@ -43,9 +41,7 @@ def remove_worktree(rm_args: RmArgs) -> Result[None, RemoveWorktreeError]:
             case Err(_) as err:
                 return err
             case Ok(_):
-                log.info(
-                    "Successfully removed worktree; worktree_branch=%s", branch_name
-                )
+                log.info("Successfully removed worktree; worktree_branch=%s", branch_name)
                 pass
 
     remaining = bare_repo.list_worktrees()
@@ -86,9 +82,7 @@ def _remove_single(
     wt_path: Path = Path(worktree.path).absolute()
 
     if str(cwd).startswith(str(wt_path)):
-        log.error(
-            "Cannot remove the worktree you are currently in; worktree_path=%s", wt_path
-        )
+        log.error("Cannot remove the worktree you are currently in; worktree_path=%s", wt_path)
         return Err(WorktreeRemoveErr())
 
     if not force:
@@ -133,9 +127,7 @@ def _has_unmerged_commits(repo: pg.Repository, git_dir: str, branch_name: str) -
                     default_branch = "main"
 
                 case Ok(config):
-                    default_branch = config.get(
-                        git_dir, "default_branch_name", fallback="main"
-                    )
+                    default_branch = config.get(git_dir, "default_branch_name", fallback="main")
 
     log.debug(
         "Checking unmerged commits; branch=%s, default_branch=%s",
@@ -144,12 +136,8 @@ def _has_unmerged_commits(repo: pg.Repository, git_dir: str, branch_name: str) -
     )
 
     try:
-        branch_commit: pg.Commit = repo.lookup_reference(
-            f"refs/heads/{branch_name}"
-        ).peel(pg.Commit)
-        default_commit: pg.Commit = repo.lookup_reference(
-            f"refs/heads/{default_branch}"
-        ).peel(pg.Commit)
+        branch_commit: pg.Commit = repo.lookup_reference(f"refs/heads/{branch_name}").peel(pg.Commit)
+        default_commit: pg.Commit = repo.lookup_reference(f"refs/heads/{default_branch}").peel(pg.Commit)
 
         merge_base: pg.Oid = repo.merge_base(branch_commit.id, default_commit.id)
 

--- a/src/cmds/rm/result_rm.py
+++ b/src/cmds/rm/result_rm.py
@@ -7,11 +7,5 @@ from ...errors.worktree_not_found_err import WorktreeNotFoundErr
 from ...errors.worktree_remove_err import WorktreeRemoveErr
 
 RemoveWorktreeError = (
-    NotBareRepoErr
-    | WorktreeNotFoundErr
-    | WorktreeRemoveErr
-    | ConfigReadErr
-    | ConfigWriteErr
-    | ConfigPermErr
-    | UnmergedChangesErr
+    NotBareRepoErr | WorktreeNotFoundErr | WorktreeRemoveErr | ConfigReadErr | ConfigWriteErr | ConfigPermErr | UnmergedChangesErr
 )

--- a/src/helpers/auth_agent_callback.py
+++ b/src/helpers/auth_agent_callback.py
@@ -1,5 +1,13 @@
 import logging
-from typing import final, override
+from typing import final
+
+try:
+    from typing import override
+except ImportError:  # Python < 3.12
+
+    def override(f):  # type: ignore[misc]
+        return f
+
 
 from pygit2 import CredentialType, KeypairFromAgent, RemoteCallbacks
 from pygit2.remotes import TransferProgress

--- a/src/helpers/auth_agent_callback.py
+++ b/src/helpers/auth_agent_callback.py
@@ -24,9 +24,7 @@ class AuthAgentCallback(RemoteCallbacks):
         _ = self._progress.__enter__()
 
     @override
-    def credentials(
-        self, url: str, username_from_url: str | None, allowed_types: CredentialType
-    ):
+    def credentials(self, url: str, username_from_url: str | None, allowed_types: CredentialType):
         if allowed_types & CredentialType.SSH_KEY:
             return KeypairFromAgent(username_from_url or "git")
 
@@ -56,6 +54,4 @@ class AuthAgentCallback(RemoteCallbacks):
                 completed=stats.indexed_objects,
             )
 
-        self._progress.update(
-            self._task, description=None, completed=stats.indexed_objects, refresh=True
-        )
+        self._progress.update(self._task, description=None, completed=stats.indexed_objects, refresh=True)

--- a/src/helpers/auth_agent_callback.py
+++ b/src/helpers/auth_agent_callback.py
@@ -1,65 +1,43 @@
 import logging
-from typing import final
-
-try:
-    from typing import override
-except ImportError:  # Python < 3.12
-
-    def override(f):  # type: ignore[misc]
-        return f
-
+from typing import final, override
 
 from pygit2 import CredentialType, KeypairFromAgent, RemoteCallbacks
 from pygit2.remotes import TransferProgress
 from rich.progress import Progress
 
 from ..errors.git_auth_error import GitAuthError
-from .logger import console
 
 
 @final
 class AuthAgentCallback(RemoteCallbacks):
     def __init__(self):
         super().__init__()
-
-        self._progress = Progress(
-            redirect_stderr=True,
-            redirect_stdout=True,
-            console=console,  # same console as RichHandler
-        )
-
-        _ = self._task = None
-        _ = self._progress.__enter__()
+        self._progress = Progress(transient=True, auto_refresh=False)
+        self._task = None
 
     @override
-    def credentials(self, url: str, username_from_url: str | None, allowed_types: CredentialType):
+    def credentials(self, url, username_from_url, allowed_types):
+        log = logging.getLogger(__name__)
         if allowed_types & CredentialType.SSH_KEY:
-            return KeypairFromAgent(username_from_url or "git")
+            log.debug("Using SSH agent for credentials; url=%s, username=%s", url, username_from_url)
+            return KeypairFromAgent(username_from_url)
 
-        raise GitAuthError(f"Unsupported credential type: {allowed_types}")
+        log.error("No supported credential type available; url=%s, allowed_types=%s", url, allowed_types)
+        raise GitAuthError()
 
     @override
     def transfer_progress(self, stats: TransferProgress):
-        log = logging.getLogger(__name__)
-
         if stats.total_objects == 0:
             return
 
-        if stats.total_objects == stats.indexed_objects:
-            log.debug(
-                "Downloading finished; total_objects=%s, processed_objects=%s",
-                stats.total_objects,
-                stats.indexed_objects,
-            )
+        if not self._progress.live.is_started:
+            self._progress.start()
 
-            self._progress.__exit__(None, None, None)
+        if stats.received_objects == stats.total_objects:
+            self._progress.stop()
             return
 
         if self._task is None:
-            self._task = self._progress.add_task(
-                description="",
-                total=stats.total_objects,
-                completed=stats.indexed_objects,
-            )
+            self._task = self._progress.add_task(description="", total=stats.total_objects, completed=stats.indexed_objects)
 
         self._progress.update(self._task, description=None, completed=stats.indexed_objects, refresh=True)

--- a/src/helpers/config_file.py
+++ b/src/helpers/config_file.py
@@ -69,17 +69,13 @@ def set_list_value(
     config.set(section, key, "\n" + "\n".join(values))
 
 
-def get_list_value(
-    config: configparser.RawConfigParser, section: str, key: str
-) -> list[str]:
+def get_list_value(config: configparser.RawConfigParser, section: str, key: str) -> list[str]:
     raw = config.get(section, key, fallback="")
 
     return [line.strip() for line in raw.splitlines() if line.strip()]
 
 
-def write_config_file(
-    config: configparser.RawConfigParser, path: Path
-) -> Result[None, ConfigWriteErr]:
+def write_config_file(config: configparser.RawConfigParser, path: Path) -> Result[None, ConfigWriteErr]:
     log = logging.getLogger(__name__)
 
     try:

--- a/src/main.py
+++ b/src/main.py
@@ -97,27 +97,19 @@ def add(
 
     match worktree_creaton_res:
         case Err(NotBareRepoErr()):
-            log.error(
-                "Cannot find a BARE git repository in the current working directory."
-            )
+            log.error("Cannot find a BARE git repository in the current working directory.")
             exit(ExitCode.ERR_NOT_BARE_REPO)
 
         case Err(WorktreeCreationErr()):
-            log.error(
-                "An error occurred while trying to create the new branch. Please, try again."
-            )
+            log.error("An error occurred while trying to create the new branch. Please, try again.")
             exit(ExitCode.ERR_WORKTREE)
 
         case Err(DeriveBranchDoesNotExist()):
-            log.error(
-                "The derived branch does not exist. A worktree from it cannot be created."
-            )
+            log.error("The derived branch does not exist. A worktree from it cannot be created.")
             exit(ExitCode.ERR_BRANCH_MISSING)
 
         case Err(NoFastForwardMerge()):
-            log.error(
-                "The derived branch has conflicts and cannot fast-forward changes from origin."
-            )
+            log.error("The derived branch has conflicts and cannot fast-forward changes from origin.")
             exit(ExitCode.ERR_NO_FF_MERGE)
 
         case Err(_):
@@ -198,9 +190,7 @@ def config(
 
     match config_res:
         case Err(NotBareRepoErr()):
-            log.error(
-                "Cannot find a BARE git repository in the current working directory."
-            )
+            log.error("Cannot find a BARE git repository in the current working directory.")
             exit(ExitCode.ERR_NOT_BARE_REPO)
 
         case Err(ConfigReadErr()):
@@ -309,9 +299,7 @@ def rm(branch_names: tuple[str, ...], force: bool):
 
     log = logging.getLogger(__name__)
 
-    rm_args = RmArgs(
-        branch_names=branch_names, current_working_dir=os.getcwd(), force=force
-    )
+    rm_args = RmArgs(branch_names=branch_names, current_working_dir=os.getcwd(), force=force)
 
     rm_res = remove_worktree(rm_args)
 
@@ -319,9 +307,7 @@ def rm(branch_names: tuple[str, ...], force: bool):
 
     match rm_res:
         case Err(NotBareRepoErr()):
-            log.error(
-                "Cannot find a BARE git repository in the current working directory."
-            )
+            log.error("Cannot find a BARE git repository in the current working directory.")
             exit(ExitCode.ERR_NOT_BARE_REPO)
 
         case Err(WorktreeNotFoundErr()):
@@ -329,9 +315,7 @@ def rm(branch_names: tuple[str, ...], force: bool):
             exit(ExitCode.ERR_WORKTREE_MISSING)
 
         case Err(UnmergedChangesErr()):
-            log.error(
-                "Branch has commits not in the default branch. Use --force to override."
-            )
+            log.error("Branch has commits not in the default branch. Use --force to override.")
             exit(ExitCode.ERR_UNMERGED)
 
         case Err(WorktreeRemoveErr()):
@@ -349,9 +333,7 @@ def rm(branch_names: tuple[str, ...], force: bool):
 
 @cli.command()
 @click.argument("DIRECTORY", required=True, type=str)
-@click.option(
-    "--force", "-f", is_flag=True, default=False, help="Skip confirmation prompt."
-)
+@click.option("--force", "-f", is_flag=True, default=False, help="Skip confirmation prompt.")
 def destroy(directory: str, force: bool):
     """
     Destroy an entire bare-repo worktree directory.


### PR DESCRIPTION
## Summary

Add `.github/workflows/ci.yaml` with three sequential jobs:

- **lint** — `ruff format --check src/` + `ruff check src/`
- **build** — `pip install .` + `git-wt --version`
- **test** — `pip install -e '.[dev]'` + `pytest --tb=short -q`

## Merge order

This is **#3 of 5** split from #3. Merge after `chore/ruff-format-src` (PR #7) so the lint job passes on `main` from day one. Merging before the code is formatted would cause the lint job to fail on every subsequent PR targeting `main`.

## Files changed

- `.github/workflows/ci.yaml`