### PR TITLE
chore: add git hooks for ruff checks and conventional commits

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Validate conventional commit format
+# Pattern: type(scope): message  OR  type: message
+COMMIT_MSG=$(head -1 "$1")
+PATTERN="^(feat|fix|chore|docs|style|refactor|perf|test|ci|build|revert)(\(.+\))?: .{1,72}$"
+
+if ! echo "$COMMIT_MSG" | grep -qE "$PATTERN"; then
+    echo ""
+    echo "Invalid commit message format."
+    echo "Expected: <type>(<scope>): <description>"
+    echo ""
+    echo "Types: feat, fix, chore, docs, style, refactor, perf, test, ci, build, revert"
+    echo "Max subject length: 72 chars"
+    echo ""
+    echo "Got: $COMMIT_MSG"
+    exit 1
+fi

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Check if ruff is available
+if ! command -v ruff &> /dev/null; then
+    echo "ruff not found. Install with: pip install -e '.[dev]'"
+    exit 1
+fi
+
+# Get staged Python files
+STAGED_PY=$(git diff --cached --name-only --diff-filter=ACM | grep '\.py$' || true)
+
+if [ -z "$STAGED_PY" ]; then
+    exit 0
+fi
+
+echo "Running ruff format check..."
+if ! ruff format --check $STAGED_PY; then
+    echo ""
+    echo "Format check failed. Run: ruff format src/"
+    exit 1
+fi
+
+echo "Running ruff lint..."
+if ! ruff check $STAGED_PY; then
+    echo ""
+    echo "Lint check failed. Run: ruff check --fix src/"
+    exit 1
+fi
+
+echo "All checks passed."


### PR DESCRIPTION
## Summary

Add `.githooks/` directory with two hooks. Activate with `git config core.hooksPath .githooks`.

- **pre-commit** — runs `ruff format --check` and `ruff check` on staged `.py` files. Exits 0 if no Python files are staged.
- **commit-msg** — validates conventional commit format (`type(scope): description`, max 72 chars subject). Types: feat, fix, chore, docs, style, refactor, perf, test, ci, build, revert.

## Merge order

This is **#4 of 5** split from #3. Independent — can merge in any order.

## Files changed

- `.githooks/pre-commit`
- `.githooks/commit-msg`