### PR TITLE
fix(ci): use annotated tag and scope bump detection to commit subject

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Determine bump type
         id: bump
         run: |
-          MSG="${{ github.event.head_commit.message }}"
+          MSG=$(echo "${{ github.event.head_commit.message }}" | head -1)
           if echo "$MSG" | grep -qiE "(BREAKING CHANGE|^[a-z]+(\([^)]*\))?!:)"; then
             echo "type=major" >> "$GITHUB_OUTPUT"
           elif echo "$MSG" | grep -qE "^feat(\([^)]*\))?:"; then
@@ -80,7 +80,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add pyproject.toml src/main.py
           git commit -m "chore: bump version ${{ steps.version.outputs.current }} -> ${{ steps.version.outputs.new }}"
-          git tag "v${{ steps.version.outputs.new }}"
+          git tag -a "v${{ steps.version.outputs.new }}" -m "Release v${{ steps.version.outputs.new }}"
           git push origin main --follow-tags
 
       - name: Create GitHub Release


### PR DESCRIPTION
## Summary

- Switch from lightweight to annotated git tag — `--follow-tags` only pushes annotated tags, so the lightweight tag was never reaching the remote and `gh release create` was failing
- Scope bump-type detection to first line of commit message (`head -1`) — full message body can contain `BREAKING CHANGE` in documentation text, causing false major bumps (triggered 0.1.0 → 1.0.0 instead of 0.1.1 on the first pipeline run)

## Test plan

- [ ] Merge triggers pipeline
- [ ] Annotated tag `vX.Y.Z` appears on remote after run
- [ ] GitHub Release created with dist artifacts